### PR TITLE
Fix emoji rendering in og images

### DIFF
--- a/src/lib/og-emoji.server.ts
+++ b/src/lib/og-emoji.server.ts
@@ -1,0 +1,97 @@
+/**
+ * Apple-emoji loader for Satori OG renderers. When Satori segments JSX text and finds an
+ * emoji glyph it calls `loadAdditionalAsset(code, segment)` with `code === "emoji"`. The
+ * bundled Inter font has no color emoji, so without this loader emoji come out as missing-
+ * glyph rectangles ("tofu").
+ *
+ * We resolve each emoji to a 64×64 Apple-style PNG from `emoji-datasource-apple` on jsDelivr
+ * and hand Satori back a `data:` URL (Satori 0.26 inlines the bytes during render — returning
+ * a remote URL hits an internal `.trim()` on `undefined` because its fetch path assumes data
+ * was preloaded).
+ *
+ * The same module is shared across all `/og/*` routes so they render emoji identically.
+ */
+
+/**
+ * Pinned major version of the `emoji-datasource-apple` npm package. Pinning protects us from
+ * a future major reshuffling the asset path; bumping is a one-line change.
+ */
+const EMOJI_DATASOURCE_VERSION = "15";
+const EMOJI_BASE_URL = `https://cdn.jsdelivr.net/npm/emoji-datasource-apple@${EMOJI_DATASOURCE_VERSION}/img/apple/64`;
+
+/**
+ * Convert an emoji segment to the hyphenated lowercase-hex codepoint sequence used by
+ * `emoji-datasource-apple` PNG filenames. `for…of` over a string iterates by Unicode
+ * codepoint (handling UTF-16 surrogate pairs), so e.g. `👨‍💻` -> `1f468-200d-1f4bb`.
+ */
+function emojiToAppleCodepoints(emoji: string): string {
+  const codepoints: Array<string> = [];
+  for (const ch of emoji) {
+    const cp = ch.codePointAt(0);
+    if (cp === undefined) continue;
+    codepoints.push(cp.toString(16));
+  }
+  return codepoints.join("-");
+}
+
+/**
+ * Cache resolved emoji `data:` URLs (and `null` for emojis we couldn't find) for the lifetime
+ * of the worker. A single OG response can render the same emoji several times — without this
+ * we'd refetch on every occurrence and on every subsequent OG request.
+ */
+const appleEmojiCache = new Map<string, string | null>();
+
+async function fetchAppleEmojiPng(
+  codepoints: string,
+): Promise<string | undefined> {
+  const response = await fetch(`${EMOJI_BASE_URL}/${codepoints}.png`);
+  if (!response.ok) return undefined;
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.byteLength === 0) return undefined;
+  return `data:image/png;base64,${buffer.toString("base64")}`;
+}
+
+/**
+ * Satori's `loadAdditionalAsset` hook. Pass directly into `satori()` options.
+ */
+export async function loadAppleEmojiAsset(
+  code: string,
+  segment: string,
+): Promise<string | undefined> {
+  if (code !== "emoji") return undefined;
+  if (typeof segment !== "string" || segment.length === 0) return undefined;
+
+  const codepoints = emojiToAppleCodepoints(segment);
+  if (!codepoints) return undefined;
+
+  const cached = appleEmojiCache.get(codepoints);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+
+  try {
+    let dataUrl = await fetchAppleEmojiPng(codepoints);
+
+    /**
+     * `emoji-datasource-apple` indexes most assets by their fully-qualified codepoints
+     * (including `FE0F` variation selectors). A few legacy single-codepoint glyphs like
+     * `2764` (heavy black heart) live at the unqualified path. If the qualified lookup
+     * misses, retry with `FE0F` stripped so both presentations resolve.
+     */
+    if (!dataUrl && codepoints.includes("-fe0f")) {
+      const stripped = codepoints
+        .split("-")
+        .filter((c) => c !== "fe0f")
+        .join("-");
+      if (stripped && stripped !== codepoints) {
+        dataUrl = await fetchAppleEmojiPng(stripped);
+      }
+    }
+
+    appleEmojiCache.set(codepoints, dataUrl ?? null);
+    return dataUrl;
+  } catch {
+    appleEmojiCache.set(codepoints, null);
+    return undefined;
+  }
+}

--- a/src/routes/og.index.tsx
+++ b/src/routes/og.index.tsx
@@ -1,4 +1,7 @@
+import type { SatoriOptions } from "satori";
+
 import { createFileRoute } from "@tanstack/react-router";
+import { loadAppleEmojiAsset } from "#/lib/og-emoji.server";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -62,40 +65,19 @@ function getQueryText(
     : value;
 }
 
-/**
- * Strip emoji + emoji modifiers from a string. Satori can't render color emoji from the bundled
- * Inter font, so without an explicit Twemoji loader emojis come out as missing-glyph rectangles.
- * The emoji-rich variant lives at `/og/tag` (used for tag/category cards). The general OG just
- * leads with the ATStore wordmark, so dropping emojis here keeps the title clean rather than
- * pretending we have emoji rendering.
- */
-function stripEmoji(value: string) {
-  const withoutEmoji = value
-    .replaceAll(/\p{Extended_Pictographic}/gu, "")
-    .replaceAll(/\p{Emoji_Component}/gu, "");
-  const collapsedWhitespace = withoutEmoji.replaceAll(/\s+/g, " ").trim();
-  return collapsedWhitespace || "ATStore";
-}
-
 export const Route = createFileRoute("/og/")({
   server: {
     handlers: {
       GET: async ({ request }) => {
         try {
           const url = new URL(request.url);
-          const rawTitle = getQueryText(
-            url.searchParams,
-            "title",
-            "ATStore",
-            90,
-          );
+          const title = getQueryText(url.searchParams, "title", "ATStore", 90);
           const description = getQueryText(
             url.searchParams,
             "description",
             "Discover apps and tools across the Atmosphere ecosystem.",
             220,
           );
-          const title = stripEmoji(rawTitle);
           /**
            * Detect whether the title is just our brand name. If so we drop the redundant
            * "ATStore" subtitle line — the wordmark already carries it. Otherwise we show the
@@ -210,6 +192,9 @@ export const Route = createFileRoute("/og/")({
                 { name: "Inter", data: regular, weight: 400, style: "normal" },
                 { name: "Inter", data: bold, weight: 700, style: "normal" },
               ],
+              loadAdditionalAsset: loadAppleEmojiAsset as NonNullable<
+                SatoriOptions["loadAdditionalAsset"]
+              >,
             },
           );
 

--- a/src/routes/og.review.tsx
+++ b/src/routes/og.review.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
+import { loadAppleEmojiAsset } from "#/lib/og-emoji.server";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -70,68 +71,7 @@ async function getFonts() {
   return fontPromise;
 }
 
-/**
- * Twemoji loader for Satori (same approach as `/og/tag`). Lets emoji render instead of tofu.
- */
-function emojiToTwemojiCodepoints(emoji: string): string {
-  const ZWJ = "\u200D";
-  const VS16 = /\uFE0F/g;
-  const normalized = emoji.includes(ZWJ) ? emoji : emoji.replace(VS16, "");
-
-  const codepoints: Array<string> = [];
-  let highSurrogate = 0;
-  for (let i = 0; i < normalized.length; i++) {
-    const c = normalized.codePointAt(i);
-    if (c === undefined) continue;
-    if (highSurrogate) {
-      codepoints.push(
-        (
-          0x1_00_00 +
-          ((highSurrogate - 0xd8_00) << 10) +
-          (c - 0xdc_00)
-        ).toString(16),
-      );
-      highSurrogate = 0;
-    } else if (c >= 0xd8_00 && c <= 0xdb_ff) {
-      highSurrogate = c;
-    } else {
-      codepoints.push(c.toString(16));
-    }
-  }
-
-  return codepoints.join("-");
-}
-
-const twemojiSvgCache = new Map<string, string>();
-
-async function twemojiLoadAdditionalAsset(
-  code: string,
-  segment: string,
-): Promise<string | undefined> {
-  if (code !== "emoji") return undefined;
-  if (typeof segment !== "string" || segment.length === 0) return undefined;
-  const codepoints = emojiToTwemojiCodepoints(segment);
-  if (!codepoints) return undefined;
-
-  const cached = twemojiSvgCache.get(codepoints);
-  if (cached) return cached;
-
-  try {
-    const response = await fetch(
-      `https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/${codepoints}.svg`,
-    );
-    if (!response.ok) return undefined;
-    const svg = await response.text();
-    const base64 = Buffer.from(svg, "utf8").toString("base64");
-    const dataUrl = `data:image/svg+xml;base64,${base64}`;
-    twemojiSvgCache.set(codepoints, dataUrl);
-    return dataUrl;
-  } catch {
-    return undefined;
-  }
-}
-
-/** Collapse whitespace only — emoji and other characters pass through for Twemoji rendering. */
+/** Collapse whitespace only — emoji and other characters pass through for Apple-emoji rendering. */
 function normalizeOgText(value: string) {
   const s = typeof value === "string" ? value : String(value ?? "");
   return s.replaceAll(/\s+/g, " ").trim();
@@ -626,7 +566,7 @@ export const Route = createFileRoute("/og/review")({
                 { name: "Inter", data: regular, weight: 400, style: "normal" },
                 { name: "Inter", data: bold, weight: 700, style: "normal" },
               ],
-              loadAdditionalAsset: twemojiLoadAdditionalAsset as NonNullable<
+              loadAdditionalAsset: loadAppleEmojiAsset as NonNullable<
                 SatoriOptions["loadAdditionalAsset"]
               >,
             },

--- a/src/routes/og.tag.tsx
+++ b/src/routes/og.tag.tsx
@@ -1,6 +1,7 @@
 import type { SatoriOptions } from "satori";
 
 import { createFileRoute } from "@tanstack/react-router";
+import { loadAppleEmojiAsset } from "#/lib/og-emoji.server";
 import {
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
@@ -62,85 +63,6 @@ async function getFonts() {
   }
 
   return fontPromise;
-}
-
-/**
- * Convert an emoji string into the hyphenated hex codepoint sequence Twemoji uses for its
- * SVG asset filenames. This is the standard "Vercel/og + Twemoji" recipe:
- *   - drop variation selectors (\uFE0F) unless the emoji contains a ZWJ sequence
- *     (some ZWJ emojis require the FE0F to be retained for the asset to exist),
- *   - decode UTF-16 surrogate pairs into a single codepoint,
- *   - join codepoints with `-`.
- *
- * Mirrors logic from `@vercel/og`'s emoji loader so emoji like `🪪` (single codepoint),
- * `👨‍💻` (ZWJ sequence), and `✨` (basic) all resolve to a real Twemoji SVG.
- */
-function emojiToTwemojiCodepoints(emoji: string): string {
-  const ZWJ = "\u200D";
-  const VS16 = /\uFE0F/g;
-  const normalized = emoji.includes(ZWJ) ? emoji : emoji.replace(VS16, "");
-
-  const codepoints: Array<string> = [];
-  let highSurrogate = 0;
-  for (let i = 0; i < normalized.length; i++) {
-    const c = normalized.codePointAt(i);
-    if (c === undefined) continue;
-    if (highSurrogate) {
-      codepoints.push(
-        (
-          0x1_00_00 +
-          ((highSurrogate - 0xd8_00) << 10) +
-          (c - 0xdc_00)
-        ).toString(16),
-      );
-      highSurrogate = 0;
-    } else if (c >= 0xd8_00 && c <= 0xdb_ff) {
-      highSurrogate = c;
-    } else {
-      codepoints.push(c.toString(16));
-    }
-  }
-
-  return codepoints.join("-");
-}
-
-/**
- * Cache fetched Twemoji SVGs so a single OG response (which may render the same emoji five
- * times) only hits the CDN once, and so subsequent requests reuse the same data URL.
- */
-const emojiAssetCache = new Map<string, string>();
-
-/**
- * Satori's emoji hook: when it tokenizes the JSX text and finds an emoji glyph, it calls this
- * with `code === "emoji"` and the actual segment string. Satori 0.26 expects the returned
- * value to be a data URL (it inlines the bytes during render). Returning a remote URL string
- * triggers an internal `.trim()` on `undefined` because Satori's fetch path assumes data was
- * preloaded — so we fetch + base64-encode here and hand back a data URL.
- */
-async function loadAdditionalAsset(
-  code: string,
-  segment: string,
-): Promise<string | undefined> {
-  if (code !== "emoji") return undefined;
-  const codepoints = emojiToTwemojiCodepoints(segment);
-  if (!codepoints) return undefined;
-
-  const cached = emojiAssetCache.get(codepoints);
-  if (cached) return cached;
-
-  try {
-    const response = await fetch(
-      `https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/${codepoints}.svg`,
-    );
-    if (!response.ok) return undefined;
-    const svg = await response.text();
-    const base64 = Buffer.from(svg, "utf8").toString("base64");
-    const dataUrl = `data:image/svg+xml;base64,${base64}`;
-    emojiAssetCache.set(codepoints, dataUrl);
-    return dataUrl;
-  } catch {
-    return undefined;
-  }
 }
 
 function getQueryText(
@@ -368,7 +290,7 @@ export const Route = createFileRoute("/og/tag")({
                 { name: "Inter", data: regular, weight: 400, style: "normal" },
                 { name: "Inter", data: bold, weight: 700, style: "normal" },
               ],
-              loadAdditionalAsset: loadAdditionalAsset as NonNullable<
+              loadAdditionalAsset: loadAppleEmojiAsset as NonNullable<
                 SatoriOptions["loadAdditionalAsset"]
               >,
             },


### PR DESCRIPTION
- Added `src/lib/og-emoji.server.ts` — a shared Satori `loadAdditionalAsset` that resolves emoji to 64×64 PNGs from `emoji-datasource-apple` on jsDelivr, returns them as inlined `data:` URLs, and caches both hits and misses for the worker lifetime.
- Wired the loader into all three OG routes (`/og`, `/og/tag`, `/og/review`) and deleted the duplicated Twemoji loaders that previously lived in `og.tag.tsx` and `og.review.tsx`.
- Removed `stripEmoji` from `/og` so titles like `?title=Hello 🎉` now render the emoji instead of silently dropping it.

### Why
We were previously rendering Twitter/Twemoji glyphs in two routes and silently stripping emoji entirely in the third. Apple-style emoji match what most ATStore users see in their own apps and on their devices, so OG previews now look consistent with the source content.
