### PR TITLE
At fund

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ pnpm dev          # http://127.0.0.1:3000
 
 You only need to do this once per machine.
 
+**Docker (any OS)**
+
+The repo ships a `docker-compose.yml` that boots a Postgres 17 +
+pgvector container matching the default `.env.example` exactly — no
+local Postgres install needed:
+
+```bash
+docker compose up -d           # start Postgres in the background
+docker compose ps              # confirm it's healthy
+docker compose down            # stop (data persists in the named volume)
+docker compose down -v         # stop and wipe the volume (nukes the DB)
+```
+
+The container exposes `localhost:5432`, uses credentials
+`postgres:postgres`, creates the `at_store` database on first boot, and
+persists data in the `postgres_data` volume. `pnpm run setup` will
+connect to it as-is and run the `vector` extension + migrations against
+it.
+
 **macOS (Homebrew)**
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: at_store
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/drizzle/0037_fund_at_mirror_tables.sql
+++ b/drizzle/0037_fund_at_mirror_tables.sql
@@ -1,0 +1,102 @@
+CREATE TABLE "fund_actor_declarations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"at_uri" text NOT NULL,
+	"entity_type" text,
+	"role" text,
+	"record_created_at" timestamp with time zone,
+	"record_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_actor_declarations_at_uri_idx" ON "fund_actor_declarations" USING btree ("at_uri");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_actor_declarations_repo_did_idx" ON "fund_actor_declarations" USING btree ("repo_did");
+--> statement-breakpoint
+CREATE TABLE "fund_funding_contributes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"at_uri" text NOT NULL,
+	"url" text NOT NULL,
+	"label" text,
+	"record_created_at" timestamp with time zone,
+	"record_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_contributes_at_uri_idx" ON "fund_funding_contributes" USING btree ("at_uri");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_contributes_repo_did_idx" ON "fund_funding_contributes" USING btree ("repo_did");
+--> statement-breakpoint
+CREATE TABLE "fund_funding_channels" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"at_uri" text NOT NULL,
+	"channel_type" text NOT NULL,
+	"channel_uri" text,
+	"description" text,
+	"record_created_at" timestamp with time zone,
+	"record_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_channels_at_uri_idx" ON "fund_funding_channels" USING btree ("at_uri");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_channels_repo_did_rkey_idx" ON "fund_funding_channels" USING btree ("repo_did","rkey");
+--> statement-breakpoint
+CREATE INDEX "fund_funding_channels_repo_did_idx" ON "fund_funding_channels" USING btree ("repo_did");
+--> statement-breakpoint
+CREATE INDEX "fund_funding_channels_channel_type_idx" ON "fund_funding_channels" USING btree ("channel_type");
+--> statement-breakpoint
+CREATE TABLE "fund_funding_plans" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"at_uri" text NOT NULL,
+	"status" text,
+	"name" text NOT NULL,
+	"description" text,
+	"amount" bigint,
+	"currency" text,
+	"frequency" text,
+	"channel_at_uris" text[],
+	"record_created_at" timestamp with time zone,
+	"record_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_plans_at_uri_idx" ON "fund_funding_plans" USING btree ("at_uri");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_funding_plans_repo_did_rkey_idx" ON "fund_funding_plans" USING btree ("repo_did","rkey");
+--> statement-breakpoint
+CREATE INDEX "fund_funding_plans_repo_did_idx" ON "fund_funding_plans" USING btree ("repo_did");
+--> statement-breakpoint
+CREATE INDEX "fund_funding_plans_status_idx" ON "fund_funding_plans" USING btree ("status");
+--> statement-breakpoint
+CREATE TABLE "fund_graph_dependencies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"at_uri" text NOT NULL,
+	"subject_did" text NOT NULL,
+	"label" text,
+	"record_created_at" timestamp with time zone,
+	"record_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_graph_dependencies_at_uri_idx" ON "fund_graph_dependencies" USING btree ("at_uri");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "fund_graph_dependencies_repo_did_rkey_idx" ON "fund_graph_dependencies" USING btree ("repo_did","rkey");
+--> statement-breakpoint
+CREATE INDEX "fund_graph_dependencies_repo_did_idx" ON "fund_graph_dependencies" USING btree ("repo_did");
+--> statement-breakpoint
+CREATE INDEX "fund_graph_dependencies_subject_did_idx" ON "fund_graph_dependencies" USING btree ("subject_did");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1778700000000,
       "tag": "0036_product_germ_declarations",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1778800000000,
+      "tag": "0037_fund_at_mirror_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/fund-backfill-product.ts
+++ b/scripts/fund-backfill-product.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * One-off at.fund ingest: `listRecords` for the five fund.at.* collections
+ * (actor.declaration, funding.contribute, funding.channel, funding.plan,
+ *  graph.dependency) on a product DID (or Bluesky handle).
+ *
+ * Usage:
+ *   pnpm exec tsx -r dotenv/config scripts/fund-backfill-product.ts did:plc:...
+ *   pnpm exec tsx -r dotenv/config scripts/fund-backfill-product.ts handle.example.com
+ *
+ * Requires DATABASE_URL (same as the tap consumer).
+ */
+import "dotenv/config";
+import { backfillFundForProductDid } from "#/lib/atproto/fund-backfill";
+import { resolveBlueskyHandleToDid } from "#/lib/bluesky-public-profile";
+
+import { db } from "../src/db/index.server";
+
+async function main() {
+  const raw = process.argv.slice(2).join(" ").trim();
+  if (!raw) {
+    console.error(
+      "Usage: fund-backfill-product.ts <did:plc:...|handle.example.com>",
+    );
+    process.exit(1);
+  }
+
+  let did = raw.replace(/^@/, "");
+  if (!did.startsWith("did:")) {
+    const resolved = await resolveBlueskyHandleToDid(did);
+    if (!resolved) {
+      console.error(`Could not resolve handle to DID: ${did}`);
+      process.exit(1);
+    }
+    did = resolved;
+    console.log(`Resolved handle → ${did}`);
+  }
+
+  console.log(`Backfilling at.fund for ${did}…`);
+  await backfillFundForProductDid(db, did);
+  console.log("Done.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/tap-consumer.ts
+++ b/scripts/tap-consumer.ts
@@ -5,14 +5,18 @@
  * `fyi.atstore.listing.reviewReply` into `store_listing_review_replies`,
  * `fyi.atstore.listing.favorite` into `store_listing_favorites`,
  * `site.standard.publication` into `product_site_publications`,
- * `site.standard.document` into `product_site_documents`, and
- * `com.germnetwork.declaration` into `product_germ_declarations`.
+ * `site.standard.document` into `product_site_documents`,
+ * `com.germnetwork.declaration` into `product_germ_declarations`,
+ * and the five `fund.at.*` collections into the matching `fund_*` tables (read-only mirror
+ * of at.fund records — see `lib/atproto/tap-fund-*-sync.ts`).
  * Logs identity events; other record collections are skipped except `fyi.atstore.profile` (quiet).
  * Which repos and records appear is configured on the Tap *server* (indigo `cmd/tap`): set
  * `TAP_COLLECTION_FILTERS` to include `fyi.atstore.listing.detail`, `fyi.atstore.listing.review`,
  * `fyi.atstore.listing.reviewReply`, `fyi.atstore.listing.favorite`,
- * `site.standard.publication`, `site.standard.document`, `com.germnetwork.declaration`
- * (or `fyi.atstore.*` plus Standard.site and `com.germnetwork.*` filters).
+ * `site.standard.publication`, `site.standard.document`, `com.germnetwork.declaration`,
+ * `fund.at.actor.declaration`, `fund.at.funding.contribute`, `fund.at.funding.channel`,
+ * `fund.at.funding.plan`, `fund.at.graph.dependency`
+ * (or `fyi.atstore.*` plus standard.site, `com.germnetwork.*`, and `fund.at.*` collections).
  * If the server only filters `listing.detail`,
  * review / reply / favorite creates never reach
  * this WebSocket — you will see no `[record]` lines for those records. This client has no per-DID allowlist.
@@ -27,6 +31,7 @@
 import "dotenv/config";
 
 import type { IdentityEvent, RecordEvent } from "@atproto/tap";
+import type { z } from "zod";
 
 import { SimpleIndexer, Tap } from "@atproto/tap";
 import {
@@ -34,6 +39,31 @@ import {
   tryParseListingFavoriteRecord,
   upsertListingFavoriteFromTap,
 } from "#/lib/atproto/tap-favorite-sync";
+import {
+  deleteFundActorDeclarationFromTap,
+  tryParseFundActorDeclarationRecord,
+  upsertFundActorDeclarationFromTap,
+} from "#/lib/atproto/tap-fund-actor-declaration-sync";
+import {
+  deleteFundFundingChannelFromTap,
+  tryParseFundFundingChannelRecord,
+  upsertFundFundingChannelFromTap,
+} from "#/lib/atproto/tap-fund-funding-channel-sync";
+import {
+  deleteFundFundingContributeFromTap,
+  tryParseFundFundingContributeRecord,
+  upsertFundFundingContributeFromTap,
+} from "#/lib/atproto/tap-fund-funding-contribute-sync";
+import {
+  deleteFundFundingPlanFromTap,
+  tryParseFundFundingPlanRecord,
+  upsertFundFundingPlanFromTap,
+} from "#/lib/atproto/tap-fund-funding-plan-sync";
+import {
+  deleteFundGraphDependencyFromTap,
+  tryParseFundGraphDependencyRecord,
+  upsertFundGraphDependencyFromTap,
+} from "#/lib/atproto/tap-fund-graph-dependency-sync";
 import {
   deleteGermDeclarationFromTap,
   tryParseGermDeclarationRecord,
@@ -113,6 +143,90 @@ function formatRecordLog(evt: RecordEvent) {
   return `${base} live=${evt.live}`;
 }
 
+/**
+ * Per-collection plumbing for the five `fund.at.*` collections we mirror. All five share the
+ * same shape: clone → parse → upsert (or delete on tombstone). Adding a new fund collection
+ * means a single registry entry below; the dispatch loop handles cloning, first-event log,
+ * parser failure logging, and error wrapping uniformly.
+ */
+type FundParseResult<T> =
+  | { ok: true; record: T }
+  | { ok: false; reason: string; stage: string; zodError?: z.ZodError };
+
+type FundCollectionHandler<T> = {
+  /** NSID on the wire (`COLLECTION.fund...`). */
+  collection: string;
+  /** Short tag for log lines (e.g. `fund.actor.declaration`). */
+  label: string;
+  parse: (body: Record<string, unknown> | undefined) => FundParseResult<T>;
+  upsert: (input: {
+    db: Database;
+    did: string;
+    rkey: string;
+    record: T;
+    recordSource?: Record<string, unknown>;
+  }) => Promise<void>;
+  del: (input: { db: Database; did: string; rkey: string }) => Promise<void>;
+};
+
+/** Build a registry entry; the cast widens `T` to `unknown` so dispatch can hold them in one array. */
+function fundHandler<T>(
+  h: FundCollectionHandler<T>,
+): FundCollectionHandler<unknown> {
+  return h as unknown as FundCollectionHandler<unknown>;
+}
+
+async function dispatchFundRecord(
+  db: Database,
+  evt: RecordEvent,
+  h: FundCollectionHandler<unknown>,
+  firstEventSeen: Set<string>,
+): Promise<void> {
+  if (evt.action === "delete") {
+    await h.del({ db, did: evt.did, rkey: evt.rkey });
+    return;
+  }
+  if (!firstEventSeen.has(h.collection)) {
+    firstEventSeen.add(h.collection);
+    console.log(
+      `[tap] first ${h.collection} event — ensure Tap relays ${h.collection}`,
+    );
+  }
+  const raw = evt.record;
+  const body = raw === undefined ? undefined : cloneRecordForIngest(raw);
+  if (body === undefined) {
+    console.warn(
+      `[tap] ${h.label} missing record body rkey=${evt.rkey} did=${evt.did}`,
+    );
+    return;
+  }
+  const parseResult = h.parse(body);
+  if (!parseResult.ok) {
+    console.warn(
+      `[tap] skip ${h.label} rkey=${evt.rkey} did=${evt.did} stage=${parseResult.stage}: ${parseResult.reason}`,
+    );
+    if (parseResult.stage === "zod" && parseResult.zodError) {
+      console.warn("[tap] zod field errors:", parseResult.zodError.flatten());
+    }
+    return;
+  }
+  try {
+    await h.upsert({
+      db,
+      did: evt.did,
+      rkey: evt.rkey,
+      record: parseResult.record,
+      recordSource: body,
+    });
+  } catch (error) {
+    console.error(
+      `[tap] ${h.label} upsert failed rkey=${evt.rkey} did=${evt.did}`,
+      error,
+    );
+    throw error;
+  }
+}
+
 async function main() {
   if (!process.env.DATABASE_URL?.trim()) {
     console.error(
@@ -146,6 +260,11 @@ async function main() {
     COLLECTION.standardPublication,
     COLLECTION.standardDocument,
     COLLECTION.germnetworkDeclaration,
+    COLLECTION.fundActorDeclaration,
+    COLLECTION.fundFundingContribute,
+    COLLECTION.fundFundingChannel,
+    COLLECTION.fundFundingPlan,
+    COLLECTION.fundGraphDependency,
   ]);
   let firstListingDetailEvent = true;
   let firstListingReviewEvent = true;
@@ -154,6 +273,49 @@ async function main() {
   let firstStandardPublicationEvent = true;
   let firstStandardDocumentEvent = true;
   let firstGermnetworkDeclarationEvent = true;
+
+  /** Registry of `fund.at.*` collection handlers — see `dispatchFundRecord`. */
+  const fundHandlers: ReadonlyArray<FundCollectionHandler<unknown>> = [
+    fundHandler({
+      collection: COLLECTION.fundActorDeclaration,
+      label: "fund.actor.declaration",
+      parse: tryParseFundActorDeclarationRecord,
+      upsert: upsertFundActorDeclarationFromTap,
+      del: deleteFundActorDeclarationFromTap,
+    }),
+    fundHandler({
+      collection: COLLECTION.fundFundingContribute,
+      label: "fund.funding.contribute",
+      parse: tryParseFundFundingContributeRecord,
+      upsert: upsertFundFundingContributeFromTap,
+      del: deleteFundFundingContributeFromTap,
+    }),
+    fundHandler({
+      collection: COLLECTION.fundFundingChannel,
+      label: "fund.funding.channel",
+      parse: tryParseFundFundingChannelRecord,
+      upsert: upsertFundFundingChannelFromTap,
+      del: deleteFundFundingChannelFromTap,
+    }),
+    fundHandler({
+      collection: COLLECTION.fundFundingPlan,
+      label: "fund.funding.plan",
+      parse: tryParseFundFundingPlanRecord,
+      upsert: upsertFundFundingPlanFromTap,
+      del: deleteFundFundingPlanFromTap,
+    }),
+    fundHandler({
+      collection: COLLECTION.fundGraphDependency,
+      label: "fund.graph.dependency",
+      parse: tryParseFundGraphDependencyRecord,
+      upsert: upsertFundGraphDependencyFromTap,
+      del: deleteFundGraphDependencyFromTap,
+    }),
+  ];
+  const fundHandlerByCollection = new Map(
+    fundHandlers.map((h) => [h.collection, h]),
+  );
+  const fundFirstEventSeen = new Set<string>();
 
   const indexer = new SimpleIndexer();
 
@@ -182,6 +344,10 @@ async function main() {
       } else if (evt.collection.startsWith("com.germnetwork.")) {
         console.warn(
           `[tap] unexpected com.germnetwork collection (ingest ${[...ingestCollections].join(", ")}): ${evt.collection} rkey=${evt.rkey} did=${evt.did}`,
+        );
+      } else if (evt.collection.startsWith("fund.at.")) {
+        console.warn(
+          `[tap] unexpected fund.at collection (ingest ${[...ingestCollections].join(", ")}): ${evt.collection} rkey=${evt.rkey} did=${evt.did}`,
         );
       } else if (isVerbose()) {
         console.log(
@@ -609,6 +775,19 @@ async function main() {
       return;
     }
 
+    const fundHandlerForCollection = fundHandlerByCollection.get(
+      evt.collection,
+    );
+    if (fundHandlerForCollection) {
+      await dispatchFundRecord(
+        db,
+        evt,
+        fundHandlerForCollection,
+        fundFirstEventSeen,
+      );
+      return;
+    }
+
     if (evt.collection === COLLECTION.listingDetail) {
       if (evt.action !== "delete" && !evt.live) {
         console.log(
@@ -736,7 +915,7 @@ async function main() {
     `[tap] config: url=${url} ingestCollections=${[...ingestCollections].join(", ")} trustedPublishers=${trusted.size} verbose=${isVerbose()}`,
   );
   console.log(
-    `[tap] hint: Tap server TAP_COLLECTION_FILTERS must include listing.review + listing.favorite + site.standard.* + com.germnetwork.declaration (or fyi.atstore.* and Standard.site / Germ collections) or those events never arrive here`,
+    `[tap] hint: Tap server TAP_COLLECTION_FILTERS must include listing.review + listing.favorite + site.standard.* + com.germnetwork.declaration + fund.at.* (or fyi.atstore.* and Standard.site / Germ / at.fund collections) or those events never arrive here`,
   );
   console.log(
     `[tap] WebSocket channel starting (blocking) — you should see [record] lines as repos update…`,

--- a/src/components/funding-popover-chip.tsx
+++ b/src/components/funding-popover-chip.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+/**
+ * `<FundingPopoverChip/>` — pill chip on the project links row that opens a popover
+ * showing the steward's at.fund channels, plans, and dependency graph. Mirrors the
+ * `<ListingOAuthScopesPopoverChip/>` pattern so the funding affordance reads as one
+ * more piece of project metadata alongside scopes / Germ / project links.
+ */
+import type {
+  FundingChannelView,
+  FundingDependencyView,
+  FundingDetail,
+  FundingPlanView,
+} from "#/lib/atproto/load-funding-summaries";
+
+import * as stylex from "@stylexjs/stylex";
+import { Avatar } from "#/design-system/avatar";
+import { Flex } from "#/design-system/flex";
+import { Popover } from "#/design-system/popover";
+import { Separator } from "#/design-system/separator";
+import { uiColor } from "#/design-system/theme/color.stylex";
+import { radius } from "#/design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "#/design-system/theme/semantic-spacing.stylex";
+import { fontFamily, fontSize } from "#/design-system/theme/typography.stylex";
+import { SmallBody } from "#/design-system/typography";
+import { Text } from "#/design-system/typography/text";
+import {
+  deriveChannelLabel,
+  formatFundingAmount,
+} from "#/lib/atproto/fund-format";
+import { getInitials } from "#/lib/get-initials";
+import { ArrowRight, HeartHandshake } from "lucide-react";
+import { Button as AriaButton, Link as AriaLink } from "react-aria-components";
+
+const styles = stylex.create({
+  /**
+   * Pill trigger for the popover — mirrors `ListingOAuthScopesPopoverChip` so the
+   * Funding chip sits flush in the project-links row alongside Scopes / Germ.
+   */
+  chipTrigger: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    textDecoration: "none",
+    alignItems: "center",
+    backgroundColor: {
+      default: uiColor.component1,
+      ":hover": uiColor.component2,
+    },
+    color: uiColor.text2,
+    cursor: "pointer",
+    display: "inline-flex",
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.sm,
+    outlineColor: { ":focus-visible": uiColor.border2 },
+    outlineOffset: { ":focus-visible": 2 },
+    outlineStyle: { ":focus-visible": "solid" },
+    outlineWidth: { ":focus-visible": 2 },
+    paddingBottom: verticalSpace.sm,
+    paddingLeft: horizontalSpace.xl,
+    paddingRight: horizontalSpace.xl,
+    paddingTop: verticalSpace.sm,
+  },
+  chipInner: {
+    gap: gap.sm,
+    alignItems: "center",
+    display: "inline-flex",
+  },
+  popoverSurface: {
+    maxHeight: "min(480px, 78vh)",
+    maxWidth: "min(432px, 94vw)",
+    overflowX: "hidden",
+    overflowY: "auto",
+  },
+  /** Sub-label for the "Depends on" block (small caps, like a tag). */
+  sectionLabel: {
+    color: uiColor.text2,
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+  },
+  /**
+   * Pill-shaped channel/plan combo chip — same neutral palette as the surrounding
+   * link chips so funding pills sit alongside other project links without competing
+   * for attention.
+   */
+  channelPill: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    gap: gap.sm,
+    paddingBlock: verticalSpace.sm,
+    paddingInline: horizontalSpace.xl,
+    textDecoration: "none",
+    alignItems: "center",
+    backgroundColor: {
+      default: uiColor.component1,
+      ":hover": uiColor.component2,
+    },
+    color: uiColor.text1,
+    cursor: "pointer",
+    display: "inline-flex",
+    fontWeight: 600,
+  },
+  channelPillStatic: {
+    cursor: "default",
+  },
+  channelPillPrice: {
+    color: uiColor.text2,
+    fontWeight: 500,
+  },
+  /** Each "Depends on" row — full row clickable, plain link semantics. */
+  dependsRow: {
+    borderRadius: radius.md,
+    gap: gap.lg,
+    paddingBlock: verticalSpace.sm,
+    paddingInline: horizontalSpace.sm,
+    textDecoration: "none",
+    alignItems: "center",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": uiColor.component2,
+    },
+    color: uiColor.text1,
+    cursor: "pointer",
+    display: "flex",
+  },
+  dependsName: {
+    flexGrow: 1,
+    fontWeight: 600,
+    minWidth: 0,
+  },
+  arrow: {
+    color: uiColor.text2,
+    flexShrink: 0,
+    height: "1rem",
+    width: "1rem",
+  },
+});
+
+/**
+ * Index plans by the channels they reference. at.fund's design suffixes each channel
+ * pill with its plan price (e.g. "Open Collective $10/mo") — denser than rendering
+ * plans separately. Plans without a channel reference are surfaced as standalone pills.
+ */
+function buildChannelPlanIndex(
+  plans: ReadonlyArray<FundingPlanView>,
+): Map<string, FundingPlanView> {
+  const out = new Map<string, FundingPlanView>();
+  for (const plan of plans) {
+    if (plan.status === "inactive") continue;
+    for (const atUri of plan.channelAtUris) {
+      if (!out.has(atUri)) out.set(atUri, plan);
+    }
+  }
+  return out;
+}
+
+/**
+ * Hide the chip entirely when the steward declared themselves but published nothing
+ * actionable — no contribute URL, no channels/plans, no dependencies. Avoids a chip
+ * that opens to an empty popover.
+ */
+function hasActionableFunding(funding: FundingDetail): boolean {
+  return (
+    Boolean(funding.contribute?.url) ||
+    funding.channels.length > 0 ||
+    funding.plans.length > 0 ||
+    funding.dependencies.length > 0
+  );
+}
+
+export function FundingPopoverChip({
+  funding,
+  productName,
+}: {
+  funding: FundingDetail | null;
+  productName: string;
+}) {
+  if (!funding || !hasActionableFunding(funding)) return null;
+
+  return (
+    <Popover
+      placement="bottom start"
+      trigger={
+        <AriaButton
+          slot="trigger"
+          aria-haspopup="dialog"
+          aria-label={`View funding options for ${productName}`}
+          {...stylex.props(styles.chipTrigger)}
+        >
+          <span {...stylex.props(styles.chipInner)}>
+            <HeartHandshake aria-hidden size={14} strokeWidth={2} />
+            <span>Funding</span>
+          </span>
+        </AriaButton>
+      }
+      style={styles.popoverSurface}
+    >
+      <FundingPopoverContent funding={funding} />
+    </Popover>
+  );
+}
+
+function FundingPopoverContent({ funding }: { funding: FundingDetail }) {
+  const { channels, plans, dependencies } = funding;
+  const channelPlan = buildChannelPlanIndex(plans);
+  const unattachedPlans = plans.filter(
+    (plan) => plan.channelAtUris.length === 0 && plan.status !== "inactive",
+  );
+  const hasChips = channels.length > 0 || unattachedPlans.length > 0;
+
+  return (
+    <Flex direction="column" gap="2xl">
+      <Text size="lg" weight="semibold">
+        Funding
+      </Text>
+
+      {hasChips ? (
+        <Flex wrap gap="sm">
+          {channels.map((channel) => (
+            <FundingChannelPill
+              key={channel.atUri}
+              channel={channel}
+              plan={channelPlan.get(channel.atUri) ?? null}
+            />
+          ))}
+          {unattachedPlans.map((plan) => (
+            <FundingPlanPill key={plan.atUri} plan={plan} />
+          ))}
+        </Flex>
+      ) : null}
+
+      {dependencies.length > 0 ? (
+        <>
+          <Separator />
+          <Flex direction="column" gap="md">
+            <SmallBody style={styles.sectionLabel}>Depends on</SmallBody>
+            <Flex direction="column" gap="xs">
+              {dependencies.map((dep) => (
+                <FundingDependencyRow key={dep.atUri} dependency={dep} />
+              ))}
+            </Flex>
+          </Flex>
+        </>
+      ) : null}
+    </Flex>
+  );
+}
+
+function FundingChannelPill({
+  channel,
+  plan,
+}: {
+  channel: FundingChannelView;
+  plan: FundingPlanView | null;
+}) {
+  const label = deriveChannelLabel(channel);
+  const price = plan
+    ? formatFundingAmount(plan.amount, plan.currency, plan.frequency)
+    : null;
+  const isLink =
+    channel.channelUri && /^https?:/.test(channel.channelUri.trim());
+
+  const inner = (
+    <>
+      <span>{label}</span>
+      {price ? (
+        <span {...stylex.props(styles.channelPillPrice)}>{price}</span>
+      ) : null}
+    </>
+  );
+
+  if (isLink && channel.channelUri) {
+    return (
+      <AriaLink
+        href={channel.channelUri}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...stylex.props(styles.channelPill)}
+        aria-label={
+          price
+            ? `${label} — ${price} (opens in new tab)`
+            : `${label} (opens in new tab)`
+        }
+      >
+        {inner}
+      </AriaLink>
+    );
+  }
+  return (
+    <span
+      {...stylex.props(styles.channelPill, styles.channelPillStatic)}
+      aria-label={price ? `${label} — ${price}` : label}
+    >
+      {inner}
+    </span>
+  );
+}
+
+/** Channel-less plan: render the plan name + price as its own pill. */
+function FundingPlanPill({ plan }: { plan: FundingPlanView }) {
+  const price = formatFundingAmount(plan.amount, plan.currency, plan.frequency);
+  return (
+    <span
+      {...stylex.props(styles.channelPill, styles.channelPillStatic)}
+      aria-label={price ? `${plan.name} — ${price}` : plan.name}
+    >
+      <span>{plan.name}</span>
+      {price ? (
+        <span {...stylex.props(styles.channelPillPrice)}>{price}</span>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * "Depends on" row — avatar + handle/displayName + arrow. Clicks open the upstream
+ * entity's Bluesky profile (no in-store DID detail page yet; if a matching listing
+ * exists later, swap to a router link).
+ */
+function FundingDependencyRow({
+  dependency,
+}: {
+  dependency: FundingDependencyView;
+}) {
+  const name =
+    dependency.label?.trim() ||
+    dependency.displayName?.trim() ||
+    dependency.handle?.trim() ||
+    dependency.subjectDid;
+  const handle = dependency.handle?.trim();
+  const href = handle
+    ? `https://bsky.app/profile/${handle}`
+    : `https://bsky.app/profile/${dependency.subjectDid}`;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`${name} on Bluesky (opens in new tab)`}
+      {...stylex.props(styles.dependsRow)}
+    >
+      <Avatar
+        size="md"
+        alt={name}
+        fallback={getInitials(name)}
+        src={dependency.avatarUrl ?? undefined}
+      />
+      <Text size="base" weight="semibold" style={styles.dependsName}>
+        {name}
+      </Text>
+      <ArrowRight {...stylex.props(styles.arrow)} aria-hidden />
+    </a>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -402,6 +402,197 @@ export const productGermDeclarations = pgTable(
 );
 
 /**
+ * Tap / backfill mirror of `fund.at.actor.declaration` (singleton; key=literal:self) for product
+ * repos. The mere existence of the row signals the steward participates in at.fund —
+ * `entityType` and `role` are optional enrichment per the spec.
+ */
+export const fundActorDeclarations = pgTable(
+  "fund_actor_declarations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    repoDid: text("repo_did").notNull(),
+    rkey: text("rkey").notNull(),
+    atUri: text("at_uri").notNull(),
+    /** `fund.at.actor.declaration#entityType` knownValues: individual, group, collective, organisation, other. */
+    entityType: text("entity_type"),
+    /** `fund.at.actor.declaration#role` knownValues: owner, steward, maintainer, contributor, sponsor, other. */
+    role: text("role"),
+    recordCreatedAt: timestamp("record_created_at", { withTimezone: true }),
+    recordJson: jsonb("record_json"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => ({
+    atUriIdx: uniqueIndex("fund_actor_declarations_at_uri_idx").on(table.atUri),
+    /** Singleton: literal:self → only ever one row per repo. */
+    repoDidIdx: uniqueIndex("fund_actor_declarations_repo_did_idx").on(
+      table.repoDid,
+    ),
+  }),
+);
+
+/**
+ * Tap / backfill mirror of `fund.at.funding.contribute` (singleton; key=literal:self) — the
+ * canonical "Fund" URL for a steward. One row per repo.
+ */
+export const fundFundingContributes = pgTable(
+  "fund_funding_contributes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    repoDid: text("repo_did").notNull(),
+    rkey: text("rkey").notNull(),
+    atUri: text("at_uri").notNull(),
+    url: text("url").notNull(),
+    label: text("label"),
+    recordCreatedAt: timestamp("record_created_at", { withTimezone: true }),
+    recordJson: jsonb("record_json"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => ({
+    atUriIdx: uniqueIndex("fund_funding_contributes_at_uri_idx").on(
+      table.atUri,
+    ),
+    repoDidIdx: uniqueIndex("fund_funding_contributes_repo_did_idx").on(
+      table.repoDid,
+    ),
+  }),
+);
+
+/**
+ * Tap / backfill mirror of `fund.at.funding.channel` (key=any; rkey IS the slug). A repo may
+ * publish multiple channels (one per payment endpoint).
+ */
+export const fundFundingChannels = pgTable(
+  "fund_funding_channels",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    repoDid: text("repo_did").notNull(),
+    /** Channel slug — lexicon `key: "any"` makes the rkey the slug. */
+    rkey: text("rkey").notNull(),
+    atUri: text("at_uri").notNull(),
+    /** `fund.at.funding.channel#channelType` knownValues: payment-provider, bank, cheque, cash, other. */
+    channelType: text("channel_type").notNull(),
+    /** Optional payment URI — bank/cheque channels may omit a public URL. */
+    channelUri: text("channel_uri"),
+    description: text("description"),
+    recordCreatedAt: timestamp("record_created_at", { withTimezone: true }),
+    recordJson: jsonb("record_json"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => ({
+    atUriIdx: uniqueIndex("fund_funding_channels_at_uri_idx").on(table.atUri),
+    repoRkeyIdx: uniqueIndex("fund_funding_channels_repo_did_rkey_idx").on(
+      table.repoDid,
+      table.rkey,
+    ),
+    repoDidIdx: index("fund_funding_channels_repo_did_idx").on(table.repoDid),
+    channelTypeIdx: index("fund_funding_channels_channel_type_idx").on(
+      table.channelType,
+    ),
+  }),
+);
+
+/**
+ * Tap / backfill mirror of `fund.at.funding.plan` (key=any; rkey IS the slug). Plans reference
+ * channels by AT URI (`channelAtUris`) so a plan may point at channels in any account.
+ * `amount` is the smallest currency unit (e.g. cents) per spec; `0` means "any amount".
+ */
+export const fundFundingPlans = pgTable(
+  "fund_funding_plans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    repoDid: text("repo_did").notNull(),
+    rkey: text("rkey").notNull(),
+    atUri: text("at_uri").notNull(),
+    /** `fund.at.funding.plan#status` knownValues: active, inactive. */
+    status: text("status"),
+    name: text("name").notNull(),
+    description: text("description"),
+    /** Smallest currency unit (cents for USD). `0` = any amount. Stored as bigint to allow large amounts. */
+    amount: bigint("amount", { mode: "bigint" }),
+    /** ISO 4217 code, max 3 chars. */
+    currency: text("currency"),
+    /** `fund.at.funding.plan#frequency` knownValues: one-time, weekly, fortnightly, monthly, yearly, other. */
+    frequency: text("frequency"),
+    /** AT URIs of `fund.at.funding.channel` records this plan can be fulfilled through. */
+    channelAtUris: text("channel_at_uris").array(),
+    recordCreatedAt: timestamp("record_created_at", { withTimezone: true }),
+    recordJson: jsonb("record_json"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => ({
+    atUriIdx: uniqueIndex("fund_funding_plans_at_uri_idx").on(table.atUri),
+    repoRkeyIdx: uniqueIndex("fund_funding_plans_repo_did_rkey_idx").on(
+      table.repoDid,
+      table.rkey,
+    ),
+    repoDidIdx: index("fund_funding_plans_repo_did_idx").on(table.repoDid),
+    statusIdx: index("fund_funding_plans_status_idx").on(table.status),
+  }),
+);
+
+/**
+ * Tap / backfill mirror of `fund.at.graph.dependency`. The author (`repoDid`) declares they
+ * depend on `subjectDid`. Indexed both ways so we can answer "who does X depend on" and
+ * "who depends on Y".
+ */
+export const fundGraphDependencies = pgTable(
+  "fund_graph_dependencies",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    repoDid: text("repo_did").notNull(),
+    rkey: text("rkey").notNull(),
+    atUri: text("at_uri").notNull(),
+    /** `fund.at.graph.dependency#subject` — DID (did:plc:..., did:web:...). */
+    subjectDid: text("subject_did").notNull(),
+    label: text("label"),
+    recordCreatedAt: timestamp("record_created_at", { withTimezone: true }),
+    recordJson: jsonb("record_json"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => ({
+    atUriIdx: uniqueIndex("fund_graph_dependencies_at_uri_idx").on(table.atUri),
+    repoRkeyIdx: uniqueIndex("fund_graph_dependencies_repo_did_rkey_idx").on(
+      table.repoDid,
+      table.rkey,
+    ),
+    repoDidIdx: index("fund_graph_dependencies_repo_did_idx").on(table.repoDid),
+    subjectDidIdx: index("fund_graph_dependencies_subject_did_idx").on(
+      table.subjectDid,
+    ),
+  }),
+);
+
+/**
  * Append-only moderation log: each row is one admin rejection with a human-readable reason.
  * Not touched by Tap ingest. Cleared from the active UX by moving status off `rejected`, not by DELETE.
  */

--- a/src/integrations/tanstack-query/api-admin.functions.ts
+++ b/src/integrations/tanstack-query/api-admin.functions.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
+import { scheduleFundBackfillForProductDid } from "#/lib/atproto/fund-backfill";
 import { getAtstoreRepoDid } from "#/lib/atproto/publish-directory-listing";
 import { scheduleStandardSiteBackfillForProductDid } from "#/lib/atproto/standard-site-verify-backfill";
 import { scheduleGermDeclarationBackfillForProductDid } from "#/lib/atproto/tap-germ-declaration-sync";
@@ -524,6 +525,7 @@ const setListingVerification = createServerFn({ method: "POST" })
       if (productDid?.startsWith("did:")) {
         scheduleStandardSiteBackfillForProductDid(context.db, productDid);
         scheduleGermDeclarationBackfillForProductDid(context.db, productDid);
+        scheduleFundBackfillForProductDid(context.db, productDid);
       }
     }
 

--- a/src/integrations/tanstack-query/api-directory-listings.functions.ts
+++ b/src/integrations/tanstack-query/api-directory-listings.functions.ts
@@ -1,6 +1,7 @@
 import type { Database } from "#/db/index.server";
 import type { StoreListing } from "#/db/schema";
 import type { ListingLink } from "#/lib/atproto/listing-record";
+import type { FundingDetail } from "#/lib/atproto/load-funding-summaries";
 import type { SummaryScopeHumanRow } from "#/lib/oauth-listing-auth-probe";
 import type { AtprotoSessionContext } from "#/middleware/auth";
 import type { SQL } from "drizzle-orm";
@@ -11,6 +12,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import * as dbSchema from "#/db/schema";
 import { parseAtUriParts } from "#/lib/atproto/at-uri";
+import { scheduleFundBackfillForProductDid } from "#/lib/atproto/fund-backfill";
 import {
   LISTING_LINK_LABEL_MAX_LENGTH,
   LISTING_LINK_MAX_COUNT,
@@ -18,6 +20,7 @@ import {
   buildListingDetailRecordWithBlobs,
   normalizeListingLinks,
 } from "#/lib/atproto/listing-record";
+import { loadFundingDetailForDid } from "#/lib/atproto/load-funding-summaries";
 import { COLLECTION, NSID } from "#/lib/atproto/nsids";
 import {
   createAtstorePublishClient,
@@ -288,6 +291,11 @@ export interface DirectoryListingDetail extends DirectoryListingCard {
    * `verification_status` for routing (e.g. back to Manage when not live).
    */
   verificationStatus?: string;
+  /**
+   * Full at.fund detail for the rich `<FundingPanel/>` on the product page. Null when the
+   * listing has no `productAccountDid` OR no `fund.at.actor.declaration` has been mirrored.
+   */
+  fundingDetail: FundingDetail | null;
 }
 
 /** Public-safe snapshot from `store_listing_oauth_probes` (+ optional human-readable scopes from report). */
@@ -1192,10 +1200,13 @@ function toListingDetail(
     isStoreManaged: boolean;
     oauthProbe: DirectoryListingOAuthProbe | null;
     germDmHref: string | null;
+    /** at.fund full panel — hydrated by the detail handler via `loadFundingDetailForDid`. */
+    fundingDetail?: FundingDetail | null;
   },
 ): DirectoryListingDetail {
   const primary = primaryCategorySlug(row.categorySlugs);
   const assignedCategory = getDirectoryCategoryOption(primary);
+  const fundingDetail = options.fundingDetail ?? null;
 
   return {
     ...toListingCard(row),
@@ -1225,6 +1236,7 @@ function toListingDetail(
     links: normalizeListingLinks(row.links ?? null),
     oauthProbe: options.oauthProbe,
     germDmHref: options.germDmHref,
+    fundingDetail,
   };
 }
 
@@ -2388,21 +2400,24 @@ const getDirectoryListingDetail = createServerFn({ method: "GET" })
 
     const session = await getAtprotoSessionForRequest(getRequest());
 
-    const [oauthProbe, isStoreManaged, germDmHref] = await Promise.all([
-      fetchStoreListingOAuthProbe(row.id, context),
-      computeIsStoreManaged(row),
-      germDmHrefForMirroredRepoDid({
-        db: context.db,
-        schemaMod: context.schema,
-        repoDid: row.productAccountDid,
-        session,
-      }),
-    ]);
+    const [oauthProbe, isStoreManaged, germDmHref, fundingDetail] =
+      await Promise.all([
+        fetchStoreListingOAuthProbe(row.id, context),
+        computeIsStoreManaged(row),
+        germDmHrefForMirroredRepoDid({
+          db: context.db,
+          schemaMod: context.schema,
+          repoDid: row.productAccountDid,
+          session,
+        }),
+        loadFundingDetailForDid(context.db, row.productAccountDid),
+      ]);
 
     return toListingDetail(row, {
       isStoreManaged,
       oauthProbe,
       germDmHref,
+      fundingDetail,
     });
   });
 
@@ -2452,21 +2467,24 @@ const getDirectoryListingDetailBySlug = createServerFn({ method: "GET" })
 
     const session = await getAtprotoSessionForRequest(getRequest());
 
-    const [oauthProbe, isStoreManaged, germDmHref] = await Promise.all([
-      fetchStoreListingOAuthProbe(row.id, context),
-      computeIsStoreManaged(row),
-      germDmHrefForMirroredRepoDid({
-        db: context.db,
-        schemaMod: context.schema,
-        repoDid: row.productAccountDid,
-        session,
-      }),
-    ]);
+    const [oauthProbe, isStoreManaged, germDmHref, fundingDetail] =
+      await Promise.all([
+        fetchStoreListingOAuthProbe(row.id, context),
+        computeIsStoreManaged(row),
+        germDmHrefForMirroredRepoDid({
+          db: context.db,
+          schemaMod: context.schema,
+          repoDid: row.productAccountDid,
+          session,
+        }),
+        loadFundingDetailForDid(context.db, row.productAccountDid),
+      ]);
 
     return toListingDetail(row, {
       isStoreManaged,
       oauthProbe,
       germDmHref,
+      fundingDetail,
     });
   });
 
@@ -2577,22 +2595,25 @@ const getDirectoryListingDetailForOwnerEdit = createServerFn({
 
     const { verificationStatus: _removed, ...detailRow } = row;
 
-    const [oauthProbe, isStoreManaged, germDmHref] = await Promise.all([
-      fetchStoreListingOAuthProbe(row.id, context),
-      computeIsStoreManaged(row),
-      germDmHrefForMirroredRepoDid({
-        db: context.db,
-        schemaMod: context.schema,
-        repoDid: row.productAccountDid,
-        session,
-      }),
-    ]);
+    const [oauthProbe, isStoreManaged, germDmHref, fundingDetail] =
+      await Promise.all([
+        fetchStoreListingOAuthProbe(row.id, context),
+        computeIsStoreManaged(row),
+        germDmHrefForMirroredRepoDid({
+          db: context.db,
+          schemaMod: context.schema,
+          repoDid: row.productAccountDid,
+          session,
+        }),
+        loadFundingDetailForDid(context.db, row.productAccountDid),
+      ]);
 
     return {
       ...toListingDetail(detailRow as DirectoryListingDetailRow, {
         isStoreManaged,
         oauthProbe,
         germDmHref,
+        fundingDetail,
       }),
       verificationStatus: row.verificationStatus,
     };
@@ -5839,6 +5860,7 @@ const claimProductListingToPds = createServerFn({ method: "POST" })
 
       scheduleStandardSiteBackfillForProductDid(context.db, session.did);
       scheduleGermDeclarationBackfillForProductDid(context.db, session.did);
+      scheduleFundBackfillForProductDid(context.db, session.did);
 
       return { slug: inheritedSlug };
     } catch (error) {

--- a/src/integrations/tanstack-query/api-directory-listings.functions.ts
+++ b/src/integrations/tanstack-query/api-directory-listings.functions.ts
@@ -292,8 +292,9 @@ export interface DirectoryListingDetail extends DirectoryListingCard {
    */
   verificationStatus?: string;
   /**
-   * Full at.fund detail for the rich `<FundingPanel/>` on the product page. Null when the
-   * listing has no `productAccountDid` OR no `fund.at.actor.declaration` has been mirrored.
+   * Full at.fund detail for the `<FundingPopoverChip/>` on the product page. Null when
+   * the listing has no `productAccountDid` OR no `fund.at.actor.declaration` has been
+   * mirrored.
    */
   fundingDetail: FundingDetail | null;
 }

--- a/src/lib/atproto/fund-backfill.ts
+++ b/src/lib/atproto/fund-backfill.ts
@@ -1,0 +1,154 @@
+/**
+ * On-demand backfill for `fund.at.*` records — mirrors `standard-site-verify-backfill.ts`.
+ *
+ * Crawls a single product DID's PDS for the six at.fund collections we mirror and upserts
+ * each row directly (skipping the Tap-side product-DID gate, since by definition we only
+ * ever call this for a known listing's `productAccountDid`). Used in two places:
+ *   1. Admin verification approval — `setListingVerification` schedules a backfill so
+ *      previously-published fund.at.* records arrive even before Tap relays them live.
+ *   2. The owner-claim flow in `api-directory-listings.functions.ts` schedules a backfill
+ *      when a listing's productAccountDid is set/changed.
+ *
+ * Limitation: `resolveAtprotoPdsBaseUrl` only handles `did:plc:`. `did:web:` DIDs (which the
+ * at.fund spec explicitly accepts) are silently skipped today; resolving them is left for a
+ * follow-up alongside the existing TODO in `resolve-atproto-pds.ts`.
+ */
+import type { Database } from "#/db/index.server";
+
+import {
+  paginateListRecords,
+  rkeyFromCollectionAtUri,
+} from "#/lib/atproto/list-records";
+import { COLLECTION } from "#/lib/atproto/nsids";
+import { resolveAtprotoPdsBaseUrl } from "#/lib/atproto/resolve-atproto-pds";
+import {
+  tryParseFundActorDeclarationRecord,
+  upsertFundActorDeclarationIntoDb,
+} from "#/lib/atproto/tap-fund-actor-declaration-sync";
+import {
+  tryParseFundFundingChannelRecord,
+  upsertFundFundingChannelIntoDb,
+} from "#/lib/atproto/tap-fund-funding-channel-sync";
+import {
+  tryParseFundFundingContributeRecord,
+  upsertFundFundingContributeIntoDb,
+} from "#/lib/atproto/tap-fund-funding-contribute-sync";
+import {
+  tryParseFundFundingPlanRecord,
+  upsertFundFundingPlanIntoDb,
+} from "#/lib/atproto/tap-fund-funding-plan-sync";
+import {
+  tryParseFundGraphDependencyRecord,
+  upsertFundGraphDependencyIntoDb,
+} from "#/lib/atproto/tap-fund-graph-dependency-sync";
+
+async function backfillCollection<T>(
+  db: Database,
+  pds: string,
+  did: string,
+  collection: string,
+  parseRecord: (
+    body: Record<string, unknown> | undefined,
+  ) => { ok: true; record: T } | { ok: false; reason: string },
+  upsert: (input: {
+    db: Database;
+    repoDid: string;
+    rkey: string;
+    record: T;
+    recordSource?: Record<string, unknown>;
+  }) => Promise<void>,
+): Promise<void> {
+  for await (const row of paginateListRecords(pds, did, collection)) {
+    const body = row.value as Record<string, unknown> | null | undefined;
+    if (!body || typeof body !== "object") continue;
+    const rkey = rkeyFromCollectionAtUri(row.uri, collection);
+    if (!rkey) continue;
+    const parsed = parseRecord(body);
+    if (!parsed.ok) {
+      console.warn(
+        `[fund-backfill] skip ${collection} did=${did} rkey=${rkey}: ${parsed.reason}`,
+      );
+      continue;
+    }
+    await upsert({
+      db,
+      repoDid: did,
+      rkey,
+      record: parsed.record,
+      recordSource: body,
+    });
+  }
+}
+
+export async function backfillFundForProductDid(
+  db: Database,
+  productDid: string,
+): Promise<void> {
+  const did = productDid.trim();
+  if (!did.startsWith("did:")) return;
+
+  const pds = await resolveAtprotoPdsBaseUrl(did);
+  if (!pds) {
+    // did:web: support is a TODO in resolveAtprotoPdsBaseUrl — currently only did:plc:.
+    console.warn(
+      `[fund-backfill] no PDS for ${did}; skip listRecords backfill (did:web: not yet supported)`,
+    );
+    return;
+  }
+
+  await backfillCollection(
+    db,
+    pds,
+    did,
+    COLLECTION.fundActorDeclaration,
+    tryParseFundActorDeclarationRecord,
+    upsertFundActorDeclarationIntoDb,
+  );
+  await backfillCollection(
+    db,
+    pds,
+    did,
+    COLLECTION.fundFundingContribute,
+    tryParseFundFundingContributeRecord,
+    upsertFundFundingContributeIntoDb,
+  );
+  await backfillCollection(
+    db,
+    pds,
+    did,
+    COLLECTION.fundFundingChannel,
+    tryParseFundFundingChannelRecord,
+    upsertFundFundingChannelIntoDb,
+  );
+  await backfillCollection(
+    db,
+    pds,
+    did,
+    COLLECTION.fundFundingPlan,
+    tryParseFundFundingPlanRecord,
+    upsertFundFundingPlanIntoDb,
+  );
+  await backfillCollection(
+    db,
+    pds,
+    did,
+    COLLECTION.fundGraphDependency,
+    tryParseFundGraphDependencyRecord,
+    upsertFundGraphDependencyIntoDb,
+  );
+}
+
+/**
+ * Fire-and-forget PDS crawl after a listing becomes verified or its productAccountDid changes.
+ * Matches the shape of `scheduleStandardSiteBackfillForProductDid`.
+ */
+export function scheduleFundBackfillForProductDid(
+  db: Database,
+  productDid: string,
+): void {
+  const did = productDid.trim();
+  if (!did.startsWith("did:")) return;
+  void backfillFundForProductDid(db, did).catch((error) => {
+    console.error(`[fund-backfill] failed productDid=${did}`, error);
+  });
+}

--- a/src/lib/atproto/fund-format.ts
+++ b/src/lib/atproto/fund-format.ts
@@ -1,0 +1,132 @@
+/**
+ * Display formatters shared by the server-side funding loader (`load-funding-summaries.ts`)
+ * and the product-page funding panel (`<FundingPanel/>`). Both used to carry parallel copies
+ * — when at.fund ships a new payment-provider brand or frequency value, this is the only
+ * place to update.
+ */
+
+/** Channel type labels per the at.fund `channelType` knownValues. */
+export function formatChannelTypeLabel(channelType: string): string {
+  switch (channelType) {
+    case "payment-provider": {
+      return "Payment provider";
+    }
+    case "bank": {
+      return "Bank";
+    }
+    case "cheque": {
+      return "Cheque";
+    }
+    case "cash": {
+      return "Cash";
+    }
+    case "other": {
+      return "Other";
+    }
+    default: {
+      return channelType;
+    }
+  }
+}
+
+/**
+ * Map a channel record to a brand-recognisable display name. The lexicon's `channelType`
+ * is a coarse category ("payment-provider", "bank", …); for chip / pill UIs we prefer the
+ * brand humans recognise ("Ko-fi", "Open Collective"). Falls back to:
+ *
+ *   1. the steward's short `description` (≤ 32 chars) when authored,
+ *   2. the bare host of `channelUri` when it's a recognised brand or anything else,
+ *   3. the `channelType` label otherwise.
+ *
+ * Pure / sync — safe to call from both server loaders and React components.
+ */
+export function deriveChannelLabel(input: {
+  channelType: string;
+  channelUri: string | null;
+  description: string | null;
+}): string {
+  const desc = input.description?.trim();
+  if (desc && desc.length <= 32) return desc;
+
+  const uri = input.channelUri?.trim();
+  if (uri) {
+    try {
+      const u = new URL(uri);
+      const host = u.hostname.replace(/^www\./, "").toLowerCase();
+      if (host.endsWith("github.com") && u.pathname.startsWith("/sponsors/")) {
+        return "GitHub Sponsors";
+      }
+      if (host === "ko-fi.com") return "Ko-fi";
+      if (host === "opencollective.com") return "Open Collective";
+      if (host === "liberapay.com") return "Liberapay";
+      if (host === "patreon.com") return "Patreon";
+      if (host === "buymeacoffee.com") return "Buy Me a Coffee";
+      if (host === "paypal.me" || host === "paypal.com") return "PayPal";
+      if (host === "stripe.com") return "Stripe";
+      // Bare host fallback (e.g. "example.com") still beats "Payment provider".
+      return host;
+    } catch {
+      // fall through to channelType below
+    }
+  }
+  return formatChannelTypeLabel(input.channelType);
+}
+
+/** Compact "/mo" / "/yr" suffix for plan prices, mirroring at.fund's UI. */
+export function formatFrequencySuffix(frequency: string): string {
+  switch (frequency) {
+    case "weekly": {
+      return "/wk";
+    }
+    case "fortnightly": {
+      return "/2wk";
+    }
+    case "monthly": {
+      return "/mo";
+    }
+    case "yearly": {
+      return "/yr";
+    }
+    case "other": {
+      return "";
+    }
+    default: {
+      return ` / ${frequency}`;
+    }
+  }
+}
+
+/**
+ * Format a plan amount for display. The lexicon stores `amount` as the smallest currency
+ * unit (cents for USD); we convert to whole units. `0` means "any amount" per spec.
+ * Returns null when `amount` is null. Currency is uppercased ISO 4217; non-conforming
+ * values fall through to a bare numeric.
+ *
+ * Frequencies of "one-time" / "other" produce no suffix; all others add the compact
+ * `/wk` / `/mo` etc. tag from `formatFrequencySuffix`.
+ */
+export function formatFundingAmount(
+  amount: bigint | null,
+  currency: string | null,
+  frequency: string | null,
+): string | null {
+  if (amount == null) return null;
+  if (amount === 0n) return "Any amount";
+  const whole = Number(amount) / 100;
+  let formatted: string;
+  try {
+    if (currency && /^[A-Z]{3}$/.test(currency)) {
+      formatted = new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: whole < 1 ? 2 : 0,
+      }).format(whole);
+    } else {
+      formatted = `${whole.toFixed(whole < 1 ? 2 : 0)}`;
+    }
+  } catch {
+    formatted = `${whole.toFixed(whole < 1 ? 2 : 0)}${currency ? ` ${currency}` : ""}`;
+  }
+  if (!frequency || frequency === "one-time") return formatted;
+  return `${formatted}${formatFrequencySuffix(frequency)}`;
+}

--- a/src/lib/atproto/fund-format.ts
+++ b/src/lib/atproto/fund-format.ts
@@ -1,8 +1,8 @@
 /**
  * Display formatters shared by the server-side funding loader (`load-funding-summaries.ts`)
- * and the product-page funding panel (`<FundingPanel/>`). Both used to carry parallel copies
- * — when at.fund ships a new payment-provider brand or frequency value, this is the only
- * place to update.
+ * and the product-page funding popover chip (`<FundingPopoverChip/>`). Both used to carry
+ * parallel copies — when at.fund ships a new payment-provider brand or frequency value,
+ * this is the only place to update.
  */
 
 /** Channel type labels per the at.fund `channelType` knownValues. */

--- a/src/lib/atproto/fund-record-helpers.ts
+++ b/src/lib/atproto/fund-record-helpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helpers for the five `tap-fund-*-sync.ts` modules. Each fund collection ingester
+ * needs the same three primitives:
+ *
+ *   1. `cloneRecordJson` — deep clone the inbound record body for storage in `record_json`,
+ *      so we can re-derive new columns later without re-crawling. structuredClone first,
+ *      JSON fallback for environments where it throws.
+ *   2. `parseRecordCreatedAt` — turn the optional `createdAt` ISO string into a Date or null.
+ *   3. `atUriFor` — assemble `at://<did>/<collection>/<rkey>`; the per-table at-URI helpers
+ *      used to live in each sync module before this consolidation.
+ */
+export function cloneRecordJson(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(body) as Record<string, unknown>;
+    } catch {
+      // structuredClone can throw on exotic values; fall through to JSON below.
+    }
+  }
+  // eslint-disable-next-line unicorn/prefer-structured-clone -- last-resort deep clone when structuredClone is unavailable or throws
+  return JSON.parse(JSON.stringify(body)) as Record<string, unknown>;
+}
+
+/** Parse an optional ISO timestamp from the record body. Returns null on missing/invalid. */
+export function parseRecordCreatedAt(value: string | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Compose `at://<did>/<collection>/<rkey>` for an upsert target. */
+export function atUriFor(
+  did: string,
+  collection: string,
+  rkey: string,
+): string {
+  return `at://${did}/${collection}/${rkey}`;
+}

--- a/src/lib/atproto/list-records.ts
+++ b/src/lib/atproto/list-records.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared helpers for paginating `com.atproto.repo.listRecords` against a PDS.
+ *
+ * Used by `standard-site-verify-backfill.ts` and `fund-backfill.ts` to crawl arbitrary
+ * user repos without going through Tap. Pulled out so each new collection ingester can
+ * reuse a single, well-tested implementation.
+ */
+export type ListRecordRow = { uri: string; value: unknown };
+
+/**
+ * Strip the leading `at://<did>/<collection>/` from a record URI to recover the rkey.
+ * Returns null when the URI does not match the expected shape (rkey must be a single segment).
+ */
+export function rkeyFromCollectionAtUri(
+  uri: string,
+  collection: string,
+): string | null {
+  const withoutAt = uri.replace(/^at:\/\//, "");
+  const needle = `/${collection}/`;
+  const idx = withoutAt.indexOf(needle);
+  if (idx === -1) return null;
+  const rkey = withoutAt.slice(idx + needle.length);
+  if (rkey.length === 0 || rkey.includes("/")) return null;
+  return rkey;
+}
+
+/**
+ * Async-iterate every record in `<repo>/<collection>` via paginated `listRecords`.
+ * Throws on non-2xx responses (with a truncated body in the message) — callers handle
+ * the error via try/catch in their backfill orchestration.
+ */
+export async function* paginateListRecords(
+  pdsBase: string,
+  repo: string,
+  collection: string,
+): AsyncGenerator<ListRecordRow, void, undefined> {
+  let cursor: string | undefined;
+  do {
+    const u = new URL("/xrpc/com.atproto.repo.listRecords", `${pdsBase}/`);
+    u.searchParams.set("repo", repo);
+    u.searchParams.set("collection", collection);
+    u.searchParams.set("limit", "100");
+    if (cursor) u.searchParams.set("cursor", cursor);
+    const res = await fetch(u.toString(), {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `listRecords ${collection} failed ${res.status}: ${text.slice(0, 500)}`,
+      );
+    }
+    const data = (await res.json()) as {
+      records?: Array<{ uri: string; value: unknown }>;
+      cursor?: string;
+    };
+    const records = data.records ?? [];
+    for (const rec of records) {
+      yield { uri: rec.uri, value: rec.value };
+    }
+    cursor = data.cursor;
+  } while (cursor);
+}

--- a/src/lib/atproto/load-funding-summaries.ts
+++ b/src/lib/atproto/load-funding-summaries.ts
@@ -1,0 +1,408 @@
+/**
+ * Loader for at.fund funding records on the product detail page.
+ *
+ * `loadFundingDetailForDid` fetches the actual contribute / channel / plan / dependency
+ * rows for one DID so the page can render a full panel matching at.fund's
+ * "Funding / Depends on" layout.
+ */
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  deriveChannelLabel,
+  formatFundingAmount,
+} from "#/lib/atproto/fund-format";
+import { fetchBlueskyPublicProfilesBatch } from "#/lib/bluesky-public-profile";
+import { count, eq } from "drizzle-orm";
+
+/**
+ * One pill on the funding chip row — pre-computed server-side so the panel can render
+ * the at.fund-style channel pills without duplicating join logic in JSX.
+ */
+export type FundingChipView = {
+  /** Stable key (channel atUri or `plan-only:<plan atUri>` for unattached plans). */
+  key: string;
+  /** Display label (e.g. "Open Collective", "Ko-fi"). */
+  label: string;
+  /** Pre-formatted price suffix (e.g. "$10/mo") when a plan references this channel. */
+  price: string | null;
+  /** Outbound URL — null when the channel has no public URL (bank / cheque). */
+  url: string | null;
+};
+
+export type FundingSummary = {
+  /** True iff a `fund.at.actor.declaration` row exists for this DID. */
+  hasDeclaration: boolean;
+  /** `fund.at.funding.contribute#url` — null when the steward hasn't published one. */
+  contributeUrl: string | null;
+  /** Optional human-readable label for the contribute URL. */
+  contributeLabel: string | null;
+  channelCount: number;
+  planCount: number;
+  /** Number of `fund.at.graph.dependency` rows where `subjectDid = did`. */
+  dependentCount: number;
+  /**
+   * Channel-and-plan combos formatted for the listing-card chip row. Sorted by:
+   *   1. channels with active plan reference (price-bearing) before plain channels,
+   *   2. lower amount first within priced channels,
+   *   3. alphabetical fallback.
+   */
+  chips: Array<FundingChipView>;
+};
+
+export type FundingChannelView = {
+  atUri: string;
+  rkey: string;
+  channelType: string;
+  channelUri: string | null;
+  description: string | null;
+};
+
+export type FundingPlanView = {
+  atUri: string;
+  rkey: string;
+  status: string | null;
+  name: string;
+  description: string | null;
+  /** Smallest currency unit (cents for USD); null when omitted. */
+  amount: bigint | null;
+  currency: string | null;
+  frequency: string | null;
+  channelAtUris: Array<string>;
+};
+
+/**
+ * One end of a `fund.at.graph.dependency` edge with the relevant DID's Bluesky profile
+ * resolved for display. The listing → upstream direction ("Depends on"): `subjectDid`
+ * is the upstream we point to.
+ *
+ * `handle` / `displayName` / `avatarUrl` are populated from `public.api.bsky.app` and
+ * fall back to null when resolution fails.
+ */
+export type FundingDependencyView = {
+  /** AT URI of the dependency record itself (for keying in lists). */
+  atUri: string;
+  /** DID of the entity being shown — upstream for `dependencies`, downstream for `provides`. */
+  subjectDid: string;
+  /** Optional human-readable label authored on the record. */
+  label: string | null;
+  /** Resolved at render-time from public.api.bsky.app. */
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type FundingDetail = FundingSummary & {
+  contribute: { url: string; label: string | null } | null;
+  channels: Array<FundingChannelView>;
+  plans: Array<FundingPlanView>;
+  /** Upstream dependencies the steward has declared, with profile info hydrated. */
+  dependencies: Array<FundingDependencyView>;
+};
+
+type ChannelRow = {
+  repoDid: string;
+  atUri: string;
+  channelType: string;
+  channelUri: string | null;
+  description: string | null;
+};
+
+type PlanRow = {
+  repoDid: string;
+  atUri: string;
+  status: string | null;
+  name: string;
+  amount: bigint | null;
+  currency: string | null;
+  frequency: string | null;
+  channelAtUris: Array<string> | null;
+};
+
+/**
+ * Normalize a URL for loose equality comparisons — strips trailing slashes / query /
+ * fragment and lowercases the host. Returns null on parse failure.
+ */
+function normalizeUrlForEquality(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+  try {
+    const u = new URL(raw.trim());
+    const path = u.pathname.replace(/\/+$/, "");
+    return `${u.protocol}//${u.hostname.toLowerCase()}${path}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Loose URL equality used to detect which channel matches the steward's `contribute.url`.
+ * Two URLs differing only in trailing slash / case-on-host count as the same pointer.
+ * Returns false on parse failure so we never throw out of a sort comparator.
+ */
+export function urlsMatch(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  const a = normalizeUrlForEquality(left);
+  const b = normalizeUrlForEquality(right);
+  return a !== null && a === b;
+}
+
+/**
+ * Build the per-DID chip array. For each channel, find the first active plan that lists it
+ * in `channelAtUris` and use that plan's price. Plans without any channel ref render as
+ * standalone pills (rare — typically channels carry the URLs).
+ *
+ * `contributeUrl` (when present) pins the channel that matches the steward's canonical
+ * `fund.at.funding.contribute.url` to the front of the row — that's the URL the Fund
+ * button up by the heading dispatches to, so it should read first.
+ */
+function buildChipsForDid(
+  channels: ReadonlyArray<ChannelRow>,
+  plans: ReadonlyArray<PlanRow>,
+  contributeUrl: string | null,
+): Array<FundingChipView> {
+  const channelToPlan = new Map<string, PlanRow>();
+  for (const plan of plans) {
+    if (plan.status === "inactive") continue;
+    for (const atUri of plan.channelAtUris ?? []) {
+      if (!channelToPlan.has(atUri)) channelToPlan.set(atUri, plan);
+    }
+  }
+
+  const chips: Array<FundingChipView> = channels.map((c) => {
+    const plan = channelToPlan.get(c.atUri);
+    return {
+      key: c.atUri,
+      label: deriveChannelLabel(c),
+      price: plan
+        ? formatFundingAmount(plan.amount, plan.currency, plan.frequency)
+        : null,
+      url:
+        c.channelUri && /^https?:/i.test(c.channelUri.trim())
+          ? c.channelUri.trim()
+          : null,
+    };
+  });
+
+  // Plans with no channel reference (rare — render as standalone pills).
+  for (const plan of plans) {
+    if (plan.status === "inactive") continue;
+    if ((plan.channelAtUris ?? []).length > 0) continue;
+    chips.push({
+      key: `plan-only:${plan.atUri}`,
+      label: plan.name,
+      price: formatFundingAmount(plan.amount, plan.currency, plan.frequency),
+      url: null,
+    });
+  }
+
+  // Sort: contribute-matching channel first (the Fund button's destination), then
+  // priced channels (plans-attached) before plain ones, then alphabetical fallback.
+  chips.sort((a, b) => {
+    const aIsContribute = urlsMatch(a.url, contributeUrl) ? 0 : 1;
+    const bIsContribute = urlsMatch(b.url, contributeUrl) ? 0 : 1;
+    if (aIsContribute !== bIsContribute) return aIsContribute - bIsContribute;
+    const aPriced = a.price ? 0 : 1;
+    const bPriced = b.price ? 0 : 1;
+    if (aPriced !== bPriced) return aPriced - bPriced;
+    return a.label.localeCompare(b.label);
+  });
+
+  return chips;
+}
+
+/**
+ * Hydrate the full funding panel for a single DID. Returns null for DIDs we have no
+ * declaration for so the detail page can render nothing without further checks.
+ */
+export async function loadFundingDetailForDid(
+  db: Database,
+  rawDid: string | null | undefined,
+): Promise<FundingDetail | null> {
+  const did = rawDid?.trim();
+  if (!did?.startsWith("did:")) return null;
+
+  const [declarationRow] = await db
+    .select({ repoDid: schema.fundActorDeclarations.repoDid })
+    .from(schema.fundActorDeclarations)
+    .where(eq(schema.fundActorDeclarations.repoDid, did))
+    .limit(1);
+  if (!declarationRow) return null;
+
+  const [
+    contributeRows,
+    channelRows,
+    planRows,
+    dependCountRows,
+    /**
+     * Full dependency rows where `repoDid = did` (author side) → "Depends on".
+     * `subjectDid` on each row is the upstream entity to display.
+     */
+    dependencyRows,
+  ] = await Promise.all([
+    db
+      .select({
+        url: schema.fundFundingContributes.url,
+        label: schema.fundFundingContributes.label,
+      })
+      .from(schema.fundFundingContributes)
+      .where(eq(schema.fundFundingContributes.repoDid, did))
+      .limit(1),
+    db
+      .select({
+        atUri: schema.fundFundingChannels.atUri,
+        rkey: schema.fundFundingChannels.rkey,
+        channelType: schema.fundFundingChannels.channelType,
+        channelUri: schema.fundFundingChannels.channelUri,
+        description: schema.fundFundingChannels.description,
+      })
+      .from(schema.fundFundingChannels)
+      .where(eq(schema.fundFundingChannels.repoDid, did)),
+    db
+      .select({
+        atUri: schema.fundFundingPlans.atUri,
+        rkey: schema.fundFundingPlans.rkey,
+        status: schema.fundFundingPlans.status,
+        name: schema.fundFundingPlans.name,
+        description: schema.fundFundingPlans.description,
+        amount: schema.fundFundingPlans.amount,
+        currency: schema.fundFundingPlans.currency,
+        frequency: schema.fundFundingPlans.frequency,
+        channelAtUris: schema.fundFundingPlans.channelAtUris,
+      })
+      .from(schema.fundFundingPlans)
+      .where(eq(schema.fundFundingPlans.repoDid, did)),
+    db
+      .select({ n: count() })
+      .from(schema.fundGraphDependencies)
+      .where(eq(schema.fundGraphDependencies.subjectDid, did)),
+    db
+      .select({
+        atUri: schema.fundGraphDependencies.atUri,
+        subjectDid: schema.fundGraphDependencies.subjectDid,
+        label: schema.fundGraphDependencies.label,
+      })
+      .from(schema.fundGraphDependencies)
+      .where(eq(schema.fundGraphDependencies.repoDid, did)),
+  ]);
+
+  const contribute = contributeRows[0]
+    ? { url: contributeRows[0].url, label: contributeRows[0].label }
+    : null;
+
+  const channels: Array<FundingChannelView> = channelRows.map((r) => ({
+    atUri: r.atUri,
+    rkey: r.rkey,
+    channelType: r.channelType,
+    channelUri: r.channelUri,
+    description: r.description,
+  }));
+
+  const plans: Array<FundingPlanView> = planRows.map((r) => ({
+    atUri: r.atUri,
+    rkey: r.rkey,
+    status: r.status,
+    name: r.name,
+    description: r.description,
+    amount: r.amount ?? null,
+    currency: r.currency,
+    frequency: r.frequency,
+    channelAtUris: r.channelAtUris ?? [],
+  }));
+
+  /**
+   * Resolve upstream profile info via the batched `app.bsky.actor.getProfiles` (up to 25
+   * actors per HTTP call, returned as a `Map<did, profile|null>`). The per-request map
+   * also serves as our memo cache, mirroring the pattern used by the listing-mentions
+   * loader — failures and missing actors degrade to null without throwing.
+   */
+  const profilesByDid = await fetchBlueskyPublicProfilesBatch(
+    dependencyRows.map((row) => row.subjectDid),
+  );
+  const dependencies: Array<FundingDependencyView> = dependencyRows.map(
+    (row) => {
+      const profile = profilesByDid.get(row.subjectDid) ?? null;
+      return {
+        atUri: row.atUri,
+        subjectDid: row.subjectDid,
+        label: row.label,
+        handle: profile?.handle ?? null,
+        displayName: profile?.displayName ?? null,
+        avatarUrl: profile?.avatarUrl ?? null,
+      };
+    },
+  );
+
+  const contributeUrl = contribute?.url ?? null;
+
+  // Reuse the same chip computation we use for the listing-card hot path so the
+  // detail page header can pull this if it ever needs the same compact pill row.
+  const chips = buildChipsForDid(
+    channelRows.map((c) => ({
+      repoDid: did,
+      atUri: c.atUri,
+      channelType: c.channelType,
+      channelUri: c.channelUri,
+      description: c.description,
+    })),
+    planRows.map((p) => ({
+      repoDid: did,
+      atUri: p.atUri,
+      status: p.status,
+      name: p.name,
+      amount: p.amount ?? null,
+      currency: p.currency,
+      frequency: p.frequency,
+      channelAtUris: p.channelAtUris ?? null,
+    })),
+    contributeUrl,
+  );
+
+  /**
+   * Sort the raw `channels` array the same way `buildChipsForDid` sorts chips so the
+   * `<FundingPanel/>` (which iterates `channels` directly) shows the contribute-matching
+   * channel first too. Plans-attached channels come next, then alphabetical.
+   */
+  const sortedChannels: Array<FundingChannelView> = [...channels].toSorted(
+    (a, b) => {
+      const aIsContribute = urlsMatch(a.channelUri, contributeUrl) ? 0 : 1;
+      const bIsContribute = urlsMatch(b.channelUri, contributeUrl) ? 0 : 1;
+      if (aIsContribute !== bIsContribute) return aIsContribute - bIsContribute;
+      const aHasPlan = plans.some((p) => p.channelAtUris.includes(a.atUri))
+        ? 0
+        : 1;
+      const bHasPlan = plans.some((p) => p.channelAtUris.includes(b.atUri))
+        ? 0
+        : 1;
+      if (aHasPlan !== bHasPlan) return aHasPlan - bHasPlan;
+      return deriveChannelLabel({
+        channelType: a.channelType,
+        channelUri: a.channelUri,
+        description: a.description,
+      }).localeCompare(
+        deriveChannelLabel({
+          channelType: b.channelType,
+          channelUri: b.channelUri,
+          description: b.description,
+        }),
+      );
+    },
+  );
+
+  return {
+    hasDeclaration: true,
+    contributeUrl,
+    contributeLabel: contribute?.label ?? null,
+    channelCount: channels.length,
+    planCount: plans.length,
+    dependentCount: Number(dependCountRows[0]?.n ?? 0),
+    chips,
+    contribute,
+    channels: sortedChannels,
+    plans,
+    dependencies,
+  };
+}

--- a/src/lib/atproto/load-funding-summaries.ts
+++ b/src/lib/atproto/load-funding-summaries.ts
@@ -363,8 +363,9 @@ export async function loadFundingDetailForDid(
 
   /**
    * Sort the raw `channels` array the same way `buildChipsForDid` sorts chips so the
-   * `<FundingPanel/>` (which iterates `channels` directly) shows the contribute-matching
-   * channel first too. Plans-attached channels come next, then alphabetical.
+   * `<FundingPopoverChip/>` (which iterates `channels` directly) shows the
+   * contribute-matching channel first too. Plans-attached channels come next, then
+   * alphabetical.
    */
   const sortedChannels: Array<FundingChannelView> = [...channels].toSorted(
     (a, b) => {

--- a/src/lib/atproto/nsids.ts
+++ b/src/lib/atproto/nsids.ts
@@ -20,6 +20,19 @@ export const GERMNETWORK_NSID = {
   declaration: "com.germnetwork.declaration",
 } as const;
 
+/**
+ * at.fund NSIDs — lexicons owned by https://github.com/andyschwab/at.fund.
+ * ATStore mirrors these records read-only via the Tap consumer + on-demand backfill;
+ * we never publish them ourselves, so they're absent from `atproto:publish-lexicons`.
+ */
+export const FUND_NSID = {
+  actorDeclaration: "fund.at.actor.declaration",
+  fundingContribute: "fund.at.funding.contribute",
+  fundingChannel: "fund.at.funding.channel",
+  fundingPlan: "fund.at.funding.plan",
+  graphDependency: "fund.at.graph.dependency",
+} as const;
+
 export const COLLECTION = {
   authBasic: NSID.authBasic,
   profile: NSID.profile,
@@ -31,4 +44,9 @@ export const COLLECTION = {
   standardDocument: STANDARD_SITE_NSID.document,
   standardPublication: STANDARD_SITE_NSID.publication,
   germnetworkDeclaration: GERMNETWORK_NSID.declaration,
+  fundActorDeclaration: FUND_NSID.actorDeclaration,
+  fundFundingContribute: FUND_NSID.fundingContribute,
+  fundFundingChannel: FUND_NSID.fundingChannel,
+  fundFundingPlan: FUND_NSID.fundingPlan,
+  fundGraphDependency: FUND_NSID.graphDependency,
 } as const;

--- a/src/lib/atproto/standard-site-product-did-gate.ts
+++ b/src/lib/atproto/standard-site-product-did-gate.ts
@@ -1,7 +1,7 @@
 import type { Database } from "#/db/index.server";
 
 import * as schema from "#/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, or } from "drizzle-orm";
 
 /** True when some public listing uses `did` as official product account. */
 export async function hasStoreListingForProductDid(
@@ -14,6 +14,38 @@ export async function hasStoreListingForProductDid(
     .select({ id: schema.storeListings.id })
     .from(schema.storeListings)
     .where(eq(schema.storeListings.productAccountDid, trimmed))
+    .limit(1);
+  return row != null;
+}
+
+/**
+ * Gate for `fund.at.graph.dependency` records. The relationship has TWO sides — the
+ * publishing repo (`repoDid`) and the targeted entity (`subjectDid`). We keep the row
+ * when EITHER side matches a known listing's `productAccountDid`, so that dependency
+ * declarations FROM a listed app survive even when the upstream isn't listed (gives us
+ * the "depends on …" disclosure on the product page).
+ *
+ * Both DIDs are validated to be `did:`-prefixed before hitting the DB.
+ */
+export async function hasStoreListingForFundParticipant(
+  db: Database,
+  repoDid: string,
+  subjectDid: string,
+): Promise<boolean> {
+  const repo = repoDid.trim();
+  const subject = subjectDid.trim();
+  const candidates: Array<string> = [];
+  if (repo.startsWith("did:")) candidates.push(repo);
+  if (subject.startsWith("did:") && subject !== repo) candidates.push(subject);
+  if (candidates.length === 0) return false;
+  const [row] = await db
+    .select({ id: schema.storeListings.id })
+    .from(schema.storeListings)
+    .where(
+      or(
+        ...candidates.map((d) => eq(schema.storeListings.productAccountDid, d)),
+      ),
+    )
     .limit(1);
   return row != null;
 }

--- a/src/lib/atproto/standard-site-verify-backfill.ts
+++ b/src/lib/atproto/standard-site-verify-backfill.ts
@@ -1,5 +1,9 @@
 import type { Database } from "#/db/index.server";
 
+import {
+  paginateListRecords,
+  rkeyFromCollectionAtUri,
+} from "#/lib/atproto/list-records";
 import { COLLECTION } from "#/lib/atproto/nsids";
 import { resolveAtprotoPdsBaseUrl } from "#/lib/atproto/resolve-atproto-pds";
 import {
@@ -10,54 +14,6 @@ import {
   tryParseStandardPublicationRecord,
   upsertStandardPublicationIntoDb,
 } from "#/lib/atproto/tap-standard-publication-sync";
-
-type ListRecordRow = { uri: string; value: unknown };
-
-function rkeyFromCollectionAtUri(
-  uri: string,
-  collection: string,
-): string | null {
-  const withoutAt = uri.replace(/^at:\/\//, "");
-  const needle = `/${collection}/`;
-  const idx = withoutAt.indexOf(needle);
-  if (idx === -1) return null;
-  const rkey = withoutAt.slice(idx + needle.length);
-  if (rkey.length === 0 || rkey.includes("/")) return null;
-  return rkey;
-}
-
-async function* paginateListRecords(
-  pdsBase: string,
-  repo: string,
-  collection: string,
-): AsyncGenerator<ListRecordRow, void, undefined> {
-  let cursor: string | undefined;
-  do {
-    const u = new URL("/xrpc/com.atproto.repo.listRecords", `${pdsBase}/`);
-    u.searchParams.set("repo", repo);
-    u.searchParams.set("collection", collection);
-    u.searchParams.set("limit", "100");
-    if (cursor) u.searchParams.set("cursor", cursor);
-    const res = await fetch(u.toString(), {
-      headers: { Accept: "application/json" },
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(
-        `listRecords ${collection} failed ${res.status}: ${text.slice(0, 500)}`,
-      );
-    }
-    const data = (await res.json()) as {
-      records?: Array<{ uri: string; value: unknown }>;
-      cursor?: string;
-    };
-    const records = data.records ?? [];
-    for (const rec of records) {
-      yield { uri: rec.uri, value: rec.value };
-    }
-    cursor = data.cursor;
-  } while (cursor);
-}
 
 export async function backfillStandardSiteForProductDid(
   db: Database,

--- a/src/lib/atproto/tap-fund-actor-declaration-sync.ts
+++ b/src/lib/atproto/tap-fund-actor-declaration-sync.ts
@@ -1,0 +1,149 @@
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  atUriFor,
+  cloneRecordJson,
+  parseRecordCreatedAt,
+} from "#/lib/atproto/fund-record-helpers";
+import { COLLECTION, FUND_NSID } from "#/lib/atproto/nsids";
+import { hasStoreListingForProductDid } from "#/lib/atproto/standard-site-product-did-gate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * `fund.at.actor.declaration` — singleton record (lexicon `key: "literal:self"`).
+ * The mere existence of the record signals participation; both fields are optional enrichment.
+ */
+const declarationBodySchema = z.object({
+  entityType: z.string().max(32).optional(),
+  role: z.string().max(32).optional(),
+  createdAt: z.string().optional(),
+});
+
+export type FundActorDeclarationParsed = {
+  entityType?: string;
+  role?: string;
+  createdAt?: string;
+};
+
+export type FundActorDeclarationParseResult =
+  | { ok: true; record: FundActorDeclarationParsed }
+  | {
+      ok: false;
+      reason: string;
+      stage: "no_body" | "zod";
+      zodError?: z.ZodError;
+    };
+
+export function tryParseFundActorDeclarationRecord(
+  body: Record<string, unknown> | undefined,
+): FundActorDeclarationParseResult {
+  if (!body) {
+    return { ok: false, reason: "record body is missing", stage: "no_body" };
+  }
+  const t = body.$type;
+  if (
+    t !== undefined &&
+    typeof t === "string" &&
+    t !== FUND_NSID.actorDeclaration
+  ) {
+    return { ok: false, reason: `unexpected $type ${t}`, stage: "zod" };
+  }
+  const parsed = declarationBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: parsed.error.message,
+      stage: "zod",
+      zodError: parsed.error,
+    };
+  }
+  const rec: FundActorDeclarationParsed = {};
+  const e = parsed.data.entityType?.trim();
+  if (e) rec.entityType = e;
+  const r = parsed.data.role?.trim();
+  if (r) rec.role = r;
+  const c = parsed.data.createdAt?.trim();
+  if (c) rec.createdAt = c;
+  return { ok: true, record: rec };
+}
+
+export async function upsertFundActorDeclarationIntoDb(input: {
+  db: Database;
+  repoDid: string;
+  rkey: string;
+  record: FundActorDeclarationParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const { db, repoDid, rkey, record } = input;
+  const atUri = atUriFor(repoDid, COLLECTION.fundActorDeclaration, rkey);
+  const entityType = record.entityType ?? null;
+  const role = record.role ?? null;
+  const recordCreatedAt = parseRecordCreatedAt(record.createdAt);
+  const recordJson = input.recordSource
+    ? cloneRecordJson(input.recordSource)
+    : null;
+
+  await db
+    .insert(schema.fundActorDeclarations)
+    .values({
+      repoDid,
+      rkey,
+      atUri,
+      entityType,
+      role,
+      recordCreatedAt,
+      recordJson,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.fundActorDeclarations.atUri,
+      set: {
+        repoDid,
+        rkey,
+        entityType,
+        role,
+        recordCreatedAt,
+        recordJson,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function upsertFundActorDeclarationFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+  record: FundActorDeclarationParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  if (!(await hasStoreListingForProductDid(input.db, input.did))) {
+    console.warn(
+      `[tap-fund-actor-declaration] skip — no store_listings.product_account_did=${input.did} rkey=${input.rkey}`,
+    );
+    return;
+  }
+  await upsertFundActorDeclarationIntoDb({
+    db: input.db,
+    repoDid: input.did,
+    rkey: input.rkey,
+    record: input.record,
+    recordSource: input.recordSource,
+  });
+}
+
+export async function deleteFundActorDeclarationFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+}) {
+  await input.db
+    .delete(schema.fundActorDeclarations)
+    .where(
+      and(
+        eq(schema.fundActorDeclarations.repoDid, input.did),
+        eq(schema.fundActorDeclarations.rkey, input.rkey),
+      ),
+    );
+}

--- a/src/lib/atproto/tap-fund-funding-channel-sync.ts
+++ b/src/lib/atproto/tap-fund-funding-channel-sync.ts
@@ -1,0 +1,179 @@
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  atUriFor,
+  cloneRecordJson,
+  parseRecordCreatedAt,
+} from "#/lib/atproto/fund-record-helpers";
+import { COLLECTION, FUND_NSID } from "#/lib/atproto/nsids";
+import { hasStoreListingForProductDid } from "#/lib/atproto/standard-site-product-did-gate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * `fund.at.funding.channel` — keyed by `any` so the rkey IS the channel slug.
+ * `channelType` is the only required field per the lexicon. `uri` is optional (e.g. bank/cheque
+ * channels need no public URL).
+ */
+const channelBodySchema = z.object({
+  channelType: z.string().min(1).max(32),
+  uri: z.string().optional(),
+  description: z.string().max(500).optional(),
+  createdAt: z.string().optional(),
+});
+
+export type FundFundingChannelParsed = {
+  channelType: string;
+  uri?: string;
+  description?: string;
+  createdAt?: string;
+};
+
+export type FundFundingChannelParseResult =
+  | { ok: true; record: FundFundingChannelParsed }
+  | {
+      ok: false;
+      reason: string;
+      stage: "no_body" | "zod" | "uri";
+      zodError?: z.ZodError;
+    };
+
+function normalizeChannelUri(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const t = raw.trim();
+  if (!t) return null;
+  try {
+    const u = new URL(t);
+    // Channels may use https:, http:, or `at://` URIs (e.g. cross-account references).
+    if (
+      u.protocol !== "https:" &&
+      u.protocol !== "http:" &&
+      u.protocol !== "at:"
+    ) {
+      return null;
+    }
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function tryParseFundFundingChannelRecord(
+  body: Record<string, unknown> | undefined,
+): FundFundingChannelParseResult {
+  if (!body) {
+    return { ok: false, reason: "record body is missing", stage: "no_body" };
+  }
+  const t = body.$type;
+  if (
+    t !== undefined &&
+    typeof t === "string" &&
+    t !== FUND_NSID.fundingChannel
+  ) {
+    return { ok: false, reason: `unexpected $type ${t}`, stage: "zod" };
+  }
+  const parsed = channelBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: parsed.error.message,
+      stage: "zod",
+      zodError: parsed.error,
+    };
+  }
+  const channelType = parsed.data.channelType.trim();
+  if (!channelType) {
+    return { ok: false, reason: "channelType is empty", stage: "zod" };
+  }
+  const rec: FundFundingChannelParsed = { channelType };
+  // Optional URI — invalid URIs drop the field rather than failing the record.
+  const uri = normalizeChannelUri(parsed.data.uri);
+  if (uri) rec.uri = uri;
+  const d = parsed.data.description?.trim();
+  if (d) rec.description = d;
+  const c = parsed.data.createdAt?.trim();
+  if (c) rec.createdAt = c;
+  return { ok: true, record: rec };
+}
+
+export async function upsertFundFundingChannelIntoDb(input: {
+  db: Database;
+  repoDid: string;
+  rkey: string;
+  record: FundFundingChannelParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const { db, repoDid, rkey, record } = input;
+  const atUri = atUriFor(repoDid, COLLECTION.fundFundingChannel, rkey);
+  const channelUri = record.uri ?? null;
+  const description = record.description ?? null;
+  const recordCreatedAt = parseRecordCreatedAt(record.createdAt);
+  const recordJson = input.recordSource
+    ? cloneRecordJson(input.recordSource)
+    : null;
+
+  await db
+    .insert(schema.fundFundingChannels)
+    .values({
+      repoDid,
+      rkey,
+      atUri,
+      channelType: record.channelType,
+      channelUri,
+      description,
+      recordCreatedAt,
+      recordJson,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.fundFundingChannels.atUri,
+      set: {
+        repoDid,
+        rkey,
+        channelType: record.channelType,
+        channelUri,
+        description,
+        recordCreatedAt,
+        recordJson,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function upsertFundFundingChannelFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+  record: FundFundingChannelParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  if (!(await hasStoreListingForProductDid(input.db, input.did))) {
+    console.warn(
+      `[tap-fund-funding-channel] skip — no store_listings.product_account_did=${input.did} rkey=${input.rkey}`,
+    );
+    return;
+  }
+  await upsertFundFundingChannelIntoDb({
+    db: input.db,
+    repoDid: input.did,
+    rkey: input.rkey,
+    record: input.record,
+    recordSource: input.recordSource,
+  });
+}
+
+export async function deleteFundFundingChannelFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+}) {
+  await input.db
+    .delete(schema.fundFundingChannels)
+    .where(
+      and(
+        eq(schema.fundFundingChannels.repoDid, input.did),
+        eq(schema.fundFundingChannels.rkey, input.rkey),
+      ),
+    );
+}

--- a/src/lib/atproto/tap-fund-funding-contribute-sync.test.ts
+++ b/src/lib/atproto/tap-fund-funding-contribute-sync.test.ts
@@ -1,0 +1,65 @@
+import { tryParseFundFundingContributeRecord } from "#/lib/atproto/tap-fund-funding-contribute-sync";
+import { describe, expect, it } from "vitest";
+
+describe("tryParseFundFundingContributeRecord", () => {
+  it("accepts a minimal valid record", () => {
+    const result = tryParseFundFundingContributeRecord({
+      $type: "fund.at.funding.contribute",
+      url: "https://github.com/sponsors/example",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.url).toBe("https://github.com/sponsors/example");
+      expect(result.record.createdAt).toBe("2026-01-01T00:00:00Z");
+    }
+  });
+
+  it("preserves an optional label", () => {
+    const result = tryParseFundFundingContributeRecord({
+      url: "https://opencollective.com/example",
+      label: "Support via Open Collective",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.label).toBe("Support via Open Collective");
+    }
+  });
+
+  it("rejects when url is missing", () => {
+    const result = tryParseFundFundingContributeRecord({
+      label: "no url",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects when url is not http(s)", () => {
+    const result = tryParseFundFundingContributeRecord({
+      url: "ftp://example.com/donate",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.stage).toBe("url");
+    }
+  });
+
+  it("rejects an unexpected $type", () => {
+    const result = tryParseFundFundingContributeRecord({
+      $type: "fund.at.funding.channel",
+      url: "https://example.com",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.stage).toBe("zod");
+    }
+  });
+
+  it("rejects when body is undefined", () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- the parser explicitly accepts undefined and surfaces a "no_body" stage
+    const result = tryParseFundFundingContributeRecord(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.stage).toBe("no_body");
+    }
+  });
+});

--- a/src/lib/atproto/tap-fund-funding-contribute-sync.ts
+++ b/src/lib/atproto/tap-fund-funding-contribute-sync.ts
@@ -1,0 +1,166 @@
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  atUriFor,
+  cloneRecordJson,
+  parseRecordCreatedAt,
+} from "#/lib/atproto/fund-record-helpers";
+import { COLLECTION, FUND_NSID } from "#/lib/atproto/nsids";
+import { hasStoreListingForProductDid } from "#/lib/atproto/standard-site-product-did-gate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * `fund.at.funding.contribute` — singleton (lexicon `key: "literal:self"`).
+ * The canonical "Fund this steward" URL — equivalent to rel="payment".
+ */
+const contributeBodySchema = z.object({
+  url: z.string().min(1),
+  label: z.string().max(128).optional(),
+  createdAt: z.string().optional(),
+});
+
+export type FundFundingContributeParsed = {
+  url: string;
+  label?: string;
+  createdAt?: string;
+};
+
+export type FundFundingContributeParseResult =
+  | { ok: true; record: FundFundingContributeParsed }
+  | {
+      ok: false;
+      reason: string;
+      stage: "no_body" | "zod" | "url";
+      zodError?: z.ZodError;
+    };
+
+function normalizeContributeUrl(raw: string): string | null {
+  const t = raw.trim();
+  if (!t) return null;
+  try {
+    const u = new URL(t);
+    if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function tryParseFundFundingContributeRecord(
+  body: Record<string, unknown> | undefined,
+): FundFundingContributeParseResult {
+  if (!body) {
+    return { ok: false, reason: "record body is missing", stage: "no_body" };
+  }
+  const t = body.$type;
+  if (
+    t !== undefined &&
+    typeof t === "string" &&
+    t !== FUND_NSID.fundingContribute
+  ) {
+    return { ok: false, reason: `unexpected $type ${t}`, stage: "zod" };
+  }
+  const parsed = contributeBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: parsed.error.message,
+      stage: "zod",
+      zodError: parsed.error,
+    };
+  }
+  const url = normalizeContributeUrl(parsed.data.url);
+  if (!url) {
+    return {
+      ok: false,
+      reason: "url is not a valid http(s) URL",
+      stage: "url",
+    };
+  }
+  const rec: FundFundingContributeParsed = { url };
+  const l = parsed.data.label?.trim();
+  if (l) rec.label = l;
+  const c = parsed.data.createdAt?.trim();
+  if (c) rec.createdAt = c;
+  return { ok: true, record: rec };
+}
+
+export async function upsertFundFundingContributeIntoDb(input: {
+  db: Database;
+  repoDid: string;
+  rkey: string;
+  record: FundFundingContributeParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const { db, repoDid, rkey, record } = input;
+  const atUri = atUriFor(repoDid, COLLECTION.fundFundingContribute, rkey);
+  const label = record.label?.trim() || null;
+  const recordCreatedAt = parseRecordCreatedAt(record.createdAt);
+  const recordJson = input.recordSource
+    ? cloneRecordJson(input.recordSource)
+    : null;
+
+  await db
+    .insert(schema.fundFundingContributes)
+    .values({
+      repoDid,
+      rkey,
+      atUri,
+      url: record.url,
+      label,
+      recordCreatedAt,
+      recordJson,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.fundFundingContributes.atUri,
+      set: {
+        repoDid,
+        rkey,
+        url: record.url,
+        label,
+        recordCreatedAt,
+        recordJson,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function upsertFundFundingContributeFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+  record: FundFundingContributeParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  if (!(await hasStoreListingForProductDid(input.db, input.did))) {
+    console.warn(
+      `[tap-fund-funding-contribute] skip — no store_listings.product_account_did=${input.did} rkey=${input.rkey}`,
+    );
+    return;
+  }
+  await upsertFundFundingContributeIntoDb({
+    db: input.db,
+    repoDid: input.did,
+    rkey: input.rkey,
+    record: input.record,
+    recordSource: input.recordSource,
+  });
+}
+
+export async function deleteFundFundingContributeFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+}) {
+  await input.db
+    .delete(schema.fundFundingContributes)
+    .where(
+      and(
+        eq(schema.fundFundingContributes.repoDid, input.did),
+        eq(schema.fundFundingContributes.rkey, input.rkey),
+      ),
+    );
+}

--- a/src/lib/atproto/tap-fund-funding-plan-sync.test.ts
+++ b/src/lib/atproto/tap-fund-funding-plan-sync.test.ts
@@ -1,0 +1,98 @@
+import { tryParseFundFundingPlanRecord } from "#/lib/atproto/tap-fund-funding-plan-sync";
+import { describe, expect, it } from "vitest";
+
+describe("tryParseFundFundingPlanRecord", () => {
+  it("accepts a fully-populated active plan", () => {
+    const result = tryParseFundFundingPlanRecord({
+      $type: "fund.at.funding.plan",
+      status: "active",
+      name: "Sustainer",
+      description: "Keeps the lights on",
+      amount: 500,
+      currency: "usd",
+      frequency: "monthly",
+      channels: [
+        "at://did:plc:abc/fund.at.funding.channel/github",
+        "at://did:plc:abc/fund.at.funding.channel/stripe",
+      ],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.name).toBe("Sustainer");
+      expect(result.record.amount).toBe(500n);
+      // Currency normalized to uppercase to match ISO 4217.
+      expect(result.record.currency).toBe("USD");
+      expect(result.record.frequency).toBe("monthly");
+      expect(result.record.channelAtUris).toEqual([
+        "at://did:plc:abc/fund.at.funding.channel/github",
+        "at://did:plc:abc/fund.at.funding.channel/stripe",
+      ]);
+    }
+  });
+
+  it("supports a minimal record (only `name`)", () => {
+    const result = tryParseFundFundingPlanRecord({ name: "Tip jar" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.name).toBe("Tip jar");
+      expect(result.record.amount).toBeUndefined();
+      expect(result.record.channelAtUris).toBeUndefined();
+    }
+  });
+
+  it("treats amount=0 as 'any amount' (per spec)", () => {
+    const result = tryParseFundFundingPlanRecord({
+      name: "Pay what you want",
+      amount: 0,
+      currency: "EUR",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.amount).toBe(0n);
+    }
+  });
+
+  it("drops non-at-uri channel entries", () => {
+    const result = tryParseFundFundingPlanRecord({
+      name: "Mixed",
+      channels: [
+        "at://did:plc:abc/fund.at.funding.channel/ok",
+        "https://example.com/not-at-uri",
+        "",
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.channelAtUris).toEqual([
+        "at://did:plc:abc/fund.at.funding.channel/ok",
+      ]);
+    }
+  });
+
+  it("rejects when name is missing", () => {
+    const result = tryParseFundFundingPlanRecord({ status: "active" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects when name is empty after trim", () => {
+    const result = tryParseFundFundingPlanRecord({ name: "   " });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects amount that is not an integer", () => {
+    const result = tryParseFundFundingPlanRecord({
+      name: "Bad amount",
+      amount: 12.5,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an unexpected $type", () => {
+    const result = tryParseFundFundingPlanRecord({
+      $type: "fund.at.funding.contribute",
+      name: "Sustainer",
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/lib/atproto/tap-fund-funding-plan-sync.ts
+++ b/src/lib/atproto/tap-fund-funding-plan-sync.ts
@@ -1,0 +1,195 @@
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  atUriFor,
+  cloneRecordJson,
+  parseRecordCreatedAt,
+} from "#/lib/atproto/fund-record-helpers";
+import { COLLECTION, FUND_NSID } from "#/lib/atproto/nsids";
+import { hasStoreListingForProductDid } from "#/lib/atproto/standard-site-product-did-gate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * `fund.at.funding.plan` — keyed by `any` (rkey IS the slug).
+ * `name` is required; everything else is optional. `amount` is the smallest currency unit
+ * (per spec); `0` means "any amount". `channels` is an array of AT URIs (max 10).
+ */
+const planBodySchema = z.object({
+  status: z.string().max(16).optional(),
+  name: z.string().min(1).max(128),
+  description: z.string().max(500).optional(),
+  amount: z.number().int().optional(),
+  currency: z.string().max(3).optional(),
+  frequency: z.string().max(16).optional(),
+  channels: z.array(z.string()).max(10).optional(),
+  createdAt: z.string().optional(),
+});
+
+export type FundFundingPlanParsed = {
+  status?: string;
+  name: string;
+  description?: string;
+  /** Smallest currency unit (cents for USD); stored as bigint to allow > 2^53. */
+  amount?: bigint;
+  /** ISO 4217 code, uppercased. */
+  currency?: string;
+  frequency?: string;
+  /** AT URIs of `fund.at.funding.channel` records. */
+  channelAtUris?: Array<string>;
+  createdAt?: string;
+};
+
+export type FundFundingPlanParseResult =
+  | { ok: true; record: FundFundingPlanParsed }
+  | {
+      ok: false;
+      reason: string;
+      stage: "no_body" | "zod";
+      zodError?: z.ZodError;
+    };
+
+function isAtUri(s: string | undefined): s is string {
+  if (!s?.trim()) return false;
+  return s.trim().startsWith("at://");
+}
+
+export function tryParseFundFundingPlanRecord(
+  body: Record<string, unknown> | undefined,
+): FundFundingPlanParseResult {
+  if (!body) {
+    return { ok: false, reason: "record body is missing", stage: "no_body" };
+  }
+  const t = body.$type;
+  if (t !== undefined && typeof t === "string" && t !== FUND_NSID.fundingPlan) {
+    return { ok: false, reason: `unexpected $type ${t}`, stage: "zod" };
+  }
+  const parsed = planBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: parsed.error.message,
+      stage: "zod",
+      zodError: parsed.error,
+    };
+  }
+  const name = parsed.data.name.trim();
+  if (!name) return { ok: false, reason: "name is empty", stage: "zod" };
+
+  const rec: FundFundingPlanParsed = { name };
+  const s = parsed.data.status?.trim();
+  if (s) rec.status = s;
+  const d = parsed.data.description?.trim();
+  if (d) rec.description = d;
+  if (parsed.data.amount !== undefined && Number.isFinite(parsed.data.amount)) {
+    rec.amount = BigInt(parsed.data.amount);
+  }
+  const cur = parsed.data.currency?.trim().toUpperCase();
+  if (cur) rec.currency = cur;
+  const f = parsed.data.frequency?.trim();
+  if (f) rec.frequency = f;
+  if (parsed.data.channels !== undefined) {
+    const filtered = parsed.data.channels
+      .map((u) => u?.trim())
+      .filter((u): u is string => isAtUri(u))
+      .slice(0, 10);
+    if (filtered.length > 0) rec.channelAtUris = filtered;
+  }
+  const c = parsed.data.createdAt?.trim();
+  if (c) rec.createdAt = c;
+  return { ok: true, record: rec };
+}
+
+export async function upsertFundFundingPlanIntoDb(input: {
+  db: Database;
+  repoDid: string;
+  rkey: string;
+  record: FundFundingPlanParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const { db, repoDid, rkey, record } = input;
+  const atUri = atUriFor(repoDid, COLLECTION.fundFundingPlan, rkey);
+  const status = record.status ?? null;
+  const description = record.description ?? null;
+  const amount = record.amount ?? null;
+  const currency = record.currency ?? null;
+  const frequency = record.frequency ?? null;
+  const channelAtUris = record.channelAtUris ?? null;
+  const recordCreatedAt = parseRecordCreatedAt(record.createdAt);
+  const recordJson = input.recordSource
+    ? cloneRecordJson(input.recordSource)
+    : null;
+
+  await db
+    .insert(schema.fundFundingPlans)
+    .values({
+      repoDid,
+      rkey,
+      atUri,
+      status,
+      name: record.name,
+      description,
+      amount,
+      currency,
+      frequency,
+      channelAtUris,
+      recordCreatedAt,
+      recordJson,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.fundFundingPlans.atUri,
+      set: {
+        repoDid,
+        rkey,
+        status,
+        name: record.name,
+        description,
+        amount,
+        currency,
+        frequency,
+        channelAtUris,
+        recordCreatedAt,
+        recordJson,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function upsertFundFundingPlanFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+  record: FundFundingPlanParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  if (!(await hasStoreListingForProductDid(input.db, input.did))) {
+    console.warn(
+      `[tap-fund-funding-plan] skip — no store_listings.product_account_did=${input.did} rkey=${input.rkey}`,
+    );
+    return;
+  }
+  await upsertFundFundingPlanIntoDb({
+    db: input.db,
+    repoDid: input.did,
+    rkey: input.rkey,
+    record: input.record,
+    recordSource: input.recordSource,
+  });
+}
+
+export async function deleteFundFundingPlanFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+}) {
+  await input.db
+    .delete(schema.fundFundingPlans)
+    .where(
+      and(
+        eq(schema.fundFundingPlans.repoDid, input.did),
+        eq(schema.fundFundingPlans.rkey, input.rkey),
+      ),
+    );
+}

--- a/src/lib/atproto/tap-fund-graph-dependency-sync.ts
+++ b/src/lib/atproto/tap-fund-graph-dependency-sync.ts
@@ -1,0 +1,163 @@
+import type { Database } from "#/db/index.server";
+
+import * as schema from "#/db/schema";
+import {
+  atUriFor,
+  cloneRecordJson,
+  parseRecordCreatedAt,
+} from "#/lib/atproto/fund-record-helpers";
+import { COLLECTION, FUND_NSID } from "#/lib/atproto/nsids";
+import { hasStoreListingForFundParticipant } from "#/lib/atproto/standard-site-product-did-gate";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+/**
+ * `fund.at.graph.dependency` — the author (`repoDid`) declares they depend on `subjectDid`.
+ * `subject` is required and must be a DID.
+ */
+const dependencyBodySchema = z.object({
+  subject: z.string().min(1).max(512),
+  label: z.string().max(128).optional(),
+  createdAt: z.string().optional(),
+});
+
+export type FundGraphDependencyParsed = {
+  subjectDid: string;
+  label?: string;
+  createdAt?: string;
+};
+
+export type FundGraphDependencyParseResult =
+  | { ok: true; record: FundGraphDependencyParsed }
+  | {
+      ok: false;
+      reason: string;
+      stage: "no_body" | "zod" | "subject";
+      zodError?: z.ZodError;
+    };
+
+export function tryParseFundGraphDependencyRecord(
+  body: Record<string, unknown> | undefined,
+): FundGraphDependencyParseResult {
+  if (!body) {
+    return { ok: false, reason: "record body is missing", stage: "no_body" };
+  }
+  const t = body.$type;
+  if (
+    t !== undefined &&
+    typeof t === "string" &&
+    t !== FUND_NSID.graphDependency
+  ) {
+    return { ok: false, reason: `unexpected $type ${t}`, stage: "zod" };
+  }
+  const parsed = dependencyBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: parsed.error.message,
+      stage: "zod",
+      zodError: parsed.error,
+    };
+  }
+  const subjectDid = parsed.data.subject.trim();
+  if (!subjectDid.startsWith("did:")) {
+    return {
+      ok: false,
+      reason: "subject is not a DID",
+      stage: "subject",
+    };
+  }
+  const rec: FundGraphDependencyParsed = { subjectDid };
+  const l = parsed.data.label?.trim();
+  if (l) rec.label = l;
+  const c = parsed.data.createdAt?.trim();
+  if (c) rec.createdAt = c;
+  return { ok: true, record: rec };
+}
+
+export async function upsertFundGraphDependencyIntoDb(input: {
+  db: Database;
+  repoDid: string;
+  rkey: string;
+  record: FundGraphDependencyParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const { db, repoDid, rkey, record } = input;
+  const atUri = atUriFor(repoDid, COLLECTION.fundGraphDependency, rkey);
+  const label = record.label ?? null;
+  const recordCreatedAt = parseRecordCreatedAt(record.createdAt);
+  const recordJson = input.recordSource
+    ? cloneRecordJson(input.recordSource)
+    : null;
+
+  await db
+    .insert(schema.fundGraphDependencies)
+    .values({
+      repoDid,
+      rkey,
+      atUri,
+      subjectDid: record.subjectDid,
+      label,
+      recordCreatedAt,
+      recordJson,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: schema.fundGraphDependencies.atUri,
+      set: {
+        repoDid,
+        rkey,
+        subjectDid: record.subjectDid,
+        label,
+        recordCreatedAt,
+        recordJson,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/**
+ * Tap wrapper — keeps the row when EITHER `repoDid` or `subjectDid` is a known listing's
+ * `productAccountDid`. See `hasStoreListingForFundParticipant` for the rationale.
+ */
+export async function upsertFundGraphDependencyFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+  record: FundGraphDependencyParsed;
+  recordSource?: Record<string, unknown>;
+}) {
+  const matched = await hasStoreListingForFundParticipant(
+    input.db,
+    input.did,
+    input.record.subjectDid,
+  );
+  if (!matched) {
+    console.warn(
+      `[tap-fund-graph-dependency] skip — no listing matches repo=${input.did} subject=${input.record.subjectDid} rkey=${input.rkey}`,
+    );
+    return;
+  }
+  await upsertFundGraphDependencyIntoDb({
+    db: input.db,
+    repoDid: input.did,
+    rkey: input.rkey,
+    record: input.record,
+    recordSource: input.recordSource,
+  });
+}
+
+export async function deleteFundGraphDependencyFromTap(input: {
+  db: Database;
+  did: string;
+  rkey: string;
+}) {
+  await input.db
+    .delete(schema.fundGraphDependencies)
+    .where(
+      and(
+        eq(schema.fundGraphDependencies.repoDid, input.did),
+        eq(schema.fundGraphDependencies.rkey, input.rkey),
+      ),
+    );
+}

--- a/src/lib/bluesky-public-profile.ts
+++ b/src/lib/bluesky-public-profile.ts
@@ -23,26 +23,87 @@ export async function fetchBlueskyPublicProfileFields(
       headers: { Accept: "application/json" },
     });
     if (!response.ok) return null;
-    const profileData = (await response.json()) as {
-      handle?: string | null;
-      displayName?: string | null;
-      avatar?: string | null;
-    };
-    const handle = profileData.handle?.trim();
-    const displayName = profileData.displayName?.trim();
-    const rawAvatar = profileData.avatar;
-    const avatarUrl =
-      typeof rawAvatar === "string" && rawAvatar.trim() !== ""
-        ? rawAvatar.trim()
-        : null;
-    return {
-      handle: handle && handle.length > 0 ? handle : null,
-      displayName: displayName && displayName.length > 0 ? displayName : null,
-      avatarUrl,
-    };
+    return normalizeProfileResponse(await response.json());
   } catch {
     return null;
   }
+}
+
+/** `app.bsky.actor.getProfiles` accepts up to 25 actors per call (server-side cap). */
+const GET_PROFILES_BATCH_SIZE = 25;
+
+function normalizeProfileResponse(raw: unknown): BlueskyPublicProfileFields {
+  const profileData = raw as {
+    handle?: string | null;
+    displayName?: string | null;
+    avatar?: string | null;
+  };
+  const handle = profileData.handle?.trim();
+  const displayName = profileData.displayName?.trim();
+  const rawAvatar = profileData.avatar;
+  const avatarUrl =
+    typeof rawAvatar === "string" && rawAvatar.trim() !== ""
+      ? rawAvatar.trim()
+      : null;
+  return {
+    handle: handle && handle.length > 0 ? handle : null,
+    displayName: displayName && displayName.length > 0 ? displayName : null,
+    avatarUrl,
+  };
+}
+
+/**
+ * Batched variant of `fetchBlueskyPublicProfileFields` — calls `app.bsky.actor.getProfiles`
+ * (max 25 actors per call) and returns a Map keyed by the DID *we requested*. Listings whose
+ * DIDs the API can't resolve map to `null` (matches the per-DID function's contract). On a
+ * batch HTTP failure every DID in that batch maps to `null` so callers don't need a
+ * second null-check path.
+ *
+ * The Map shape mirrors the per-request `Map<did, profile>` memo we use for review/mention
+ * loaders — callers can drop this in wherever they previously built that map by hand.
+ */
+export async function fetchBlueskyPublicProfilesBatch(
+  rawDids: ReadonlyArray<string>,
+): Promise<Map<string, BlueskyPublicProfileFields | null>> {
+  const out = new Map<string, BlueskyPublicProfileFields | null>();
+  const dids = [
+    ...new Set(
+      rawDids
+        .map((d) => d?.trim())
+        .filter((d): d is string => Boolean(d) && d.startsWith("did:")),
+    ),
+  ];
+  if (dids.length === 0) return out;
+
+  // Pre-seed null so a missing DID in the API response still resolves to null below.
+  for (const did of dids) out.set(did, null);
+
+  for (let i = 0; i < dids.length; i += GET_PROFILES_BATCH_SIZE) {
+    const chunk = dids.slice(i, i + GET_PROFILES_BATCH_SIZE);
+    try {
+      const url = new URL(
+        "xrpc/app.bsky.actor.getProfiles",
+        "https://public.api.bsky.app",
+      );
+      for (const did of chunk) url.searchParams.append("actors", did);
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) continue;
+      const data = (await response.json()) as {
+        profiles?: Array<{ did?: string } & Record<string, unknown>>;
+      };
+      for (const profile of data.profiles ?? []) {
+        const profileDid = (profile.did ?? "").trim();
+        if (!profileDid) continue;
+        out.set(profileDid, normalizeProfileResponse(profile));
+      }
+    } catch {
+      // Whole batch fell over — leave the pre-seeded `null`s in place.
+      continue;
+    }
+  }
+  return out;
 }
 
 /**

--- a/src/routes/_header-layout.products.$productId.index.tsx
+++ b/src/routes/_header-layout.products.$productId.index.tsx
@@ -1,4 +1,5 @@
 import type { ListingLink } from "#/lib/atproto/listing-record";
+import type { FundingDetail } from "#/lib/atproto/load-funding-summaries";
 
 import * as stylex from "@stylexjs/stylex";
 import {
@@ -17,6 +18,7 @@ import {
   useRouter,
 } from "@tanstack/react-router";
 import { BlueskyIcon } from "#/components/bluesky-icon";
+import { FundingPopoverChip } from "#/components/funding-popover-chip";
 import { useButtonStyles } from "#/design-system/theme/useButtonStyles";
 import { ToggleButton } from "#/design-system/toggle-button";
 import {
@@ -27,6 +29,7 @@ import {
   ExternalLink,
   FileText,
   Heart,
+  HeartHandshake,
   LifeBuoy,
   Link as LinkIcon,
   Mail,
@@ -533,7 +536,7 @@ const LISTING_LINK_ICONS = {
   source: Code2,
   license: Scale,
   status: Zap,
-  donate: Heart,
+  donate: HeartHandshake,
   other: LinkIcon,
 } as const satisfies Record<string, typeof LinkIcon>;
 
@@ -580,6 +583,8 @@ function ListingLinksRow({
   externalUrl,
   oauthProbe,
   germDmHref,
+  fundingDetail,
+  productName,
   devListingId,
   devListingSlug,
 }: {
@@ -587,6 +592,8 @@ function ListingLinksRow({
   externalUrl: string | null | undefined;
   oauthProbe: DirectoryListingOAuthProbe | null;
   germDmHref: string | null | undefined;
+  fundingDetail: FundingDetail | null;
+  productName: string;
   devListingId?: string;
   devListingSlug?: string | null;
 }) {
@@ -599,7 +606,24 @@ function ListingLinksRow({
   const trimmedGermHref =
     typeof germDmHref === "string" ? germDmHref.trim() : "";
   const germHrefChip = trimmedGermHref.length > 0 ? trimmedGermHref : null;
-  if (links.length === 0 && !showScopesChip && !germHrefChip) {
+  /**
+   * Funding chip is gated on at least one actionable field (URL / channel / plan /
+   * dependency); a bare declaration with nothing else attached doesn't render.
+   * `<FundingPopoverChip/>` returns null in that case so we can mirror the gate here
+   * for the row-level "do we render anything" check.
+   */
+  const showFundingChip =
+    fundingDetail != null &&
+    (Boolean(fundingDetail.contribute?.url) ||
+      fundingDetail.channels.length > 0 ||
+      fundingDetail.plans.length > 0 ||
+      fundingDetail.dependencies.length > 0);
+  if (
+    links.length === 0 &&
+    !showScopesChip &&
+    !germHrefChip &&
+    !showFundingChip
+  ) {
     return null;
   }
 
@@ -609,7 +633,7 @@ function ListingLinksRow({
       gap="md"
       wrap
       style={styles.linksRow}
-      aria-label="Project links, OAuth scopes, and integrations"
+      aria-label="Project links, OAuth scopes, integrations, and funding"
     >
       {links.map((link, index) => {
         const Icon = getListingLinkIcon(link.type);
@@ -633,6 +657,9 @@ function ListingLinksRow({
           devListingId={devListingId}
           devListingSlug={devListingSlug}
         />
+      ) : null}
+      {showFundingChip ? (
+        <FundingPopoverChip funding={fundingDetail} productName={productName} />
       ) : null}
       {germHrefChip ? <GermNetworkBadge href={germHrefChip} /> : null}
     </Flex>
@@ -818,6 +845,8 @@ function ProductPage() {
           links={listing.links}
           oauthProbe={listing.oauthProbe}
           germDmHref={listing.germDmHref}
+          fundingDetail={listing.fundingDetail}
+          productName={listing.name}
           devListingId={listing.id}
           devListingSlug={productSlug}
         />


### PR DESCRIPTION
This resolves #35

I've tested this locally with the Margin.at account that has multi-channel funding setup - screen shot:

<img width="958" height="920" alt="Screenshot 2026-05-04 at 14 36 17" src="https://github.com/user-attachments/assets/b46d3c60-2831-472b-8088-2d303f901753" />

On the app detail page displays a funding section with chips for different funding channels and a link to the preferred location. This is populated from the at.fund records, the code to set that up is very similar to the standard.site record handlers.

<img width="331" height="358" alt="Screenshot 2026-05-04 at 14 36 37" src="https://github.com/user-attachments/assets/66ad90dc-4198-4561-a563-17a05ff61d76" />

Additionally adding a Fund chip on the all apps card - although I'm not sure it's needed here.