### PR TITLE
feat: early-exit client metadata probe on first successful hit

### DIFF
--- a/src/lib/oauth-listing-auth-probe.ts
+++ b/src/lib/oauth-listing-auth-probe.ts
@@ -1093,6 +1093,7 @@ async function ingestOAuthClientMetadataAttemptsForOrigin(
     if (result.ok || result.status !== 404) {
       clientAttempts.push({ url: u, result, scope_field });
     }
+    if (result.ok) return;
   }
 }
 


### PR DESCRIPTION
Stops requesting remaining candidate paths once any client metadata URL responds successfully, probing spec-blessed .well-known/ paths first. The result of this will be fewer requests made to apps when the metadata is returned from a common location.