### PR TITLE
Fix `nullable` fields in lexicons

### DIFF
--- a/lexicons/fyi/atstore/directory/getListing.json
+++ b/lexicons/fyi/atstore/directory/getListing.json
@@ -16,6 +16,13 @@
         "appTags",
         "categorySlugs"
       ],
+      "nullable": [
+        "iconUrl",
+        "heroImageUrl",
+        "categorySlug",
+        "rating",
+        "productAccountHandle"
+      ],
       "properties": {
         "uri": {
           "type": "string",
@@ -26,16 +33,14 @@
         "name": { "type": "string", "maxLength": 640 },
         "tagline": { "type": "string", "maxLength": 2000 },
         "description": { "type": "string", "maxLength": 20000 },
-        "iconUrl": { "type": "string", "maxLength": 8192, "nullable": true },
+        "iconUrl": { "type": "string", "maxLength": 8192 },
         "heroImageUrl": {
           "type": "string",
-          "maxLength": 8192,
-          "nullable": true
+          "maxLength": 8192
         },
         "categorySlug": {
           "type": "string",
-          "maxLength": 512,
-          "nullable": true
+          "maxLength": 512
         },
         "categorySlugs": {
           "type": "array",
@@ -49,15 +54,13 @@
         },
         "rating": {
           "type": "string",
-          "maxLength": 16,
-          "nullable": true
+          "maxLength": 16
         },
         "reviewCount": { "type": "integer" },
         "priceLabel": { "type": "string", "maxLength": 32 },
         "productAccountHandle": {
           "type": "string",
-          "maxLength": 512,
-          "nullable": true
+          "maxLength": 512
         },
         "appTags": {
           "type": "array",
@@ -76,27 +79,34 @@
     "listingDetailResponse": {
       "type": "object",
       "required": ["listing", "isStoreManaged"],
+      "nullable": [
+        "repoDid",
+        "productAccountDid",
+        "sourceTagline",
+        "sourceFullDescription",
+        "externalUrl",
+        "sourceUrl",
+        "createdAt",
+        "updatedAt"
+      ],
       "properties": {
         "listing": {
           "type": "ref",
           "ref": "#listingCardGet"
         },
         "isStoreManaged": { "type": "boolean" },
-        "repoDid": { "type": "string", "maxLength": 2048, "nullable": true },
+        "repoDid": { "type": "string", "maxLength": 2048 },
         "productAccountDid": {
           "type": "string",
-          "maxLength": 2048,
-          "nullable": true
+          "maxLength": 2048
         },
         "sourceTagline": {
           "type": "string",
-          "maxLength": 20000,
-          "nullable": true
+          "maxLength": 20000
         },
         "sourceFullDescription": {
           "type": "string",
-          "maxLength": 20000,
-          "nullable": true
+          "maxLength": 20000
         },
         "screenshots": {
           "type": "array",
@@ -104,12 +114,11 @@
         },
         "externalUrl": {
           "type": "string",
-          "maxLength": 2048,
-          "nullable": true
+          "maxLength": 2048
         },
-        "sourceUrl": { "type": "string", "maxLength": 8192, "nullable": true },
-        "createdAt": { "type": "string", "maxLength": 64, "nullable": true },
-        "updatedAt": { "type": "string", "maxLength": 64, "nullable": true },
+        "sourceUrl": { "type": "string", "maxLength": 8192 },
+        "createdAt": { "type": "string", "maxLength": 64 },
+        "updatedAt": { "type": "string", "maxLength": 64 },
         "links": {
           "type": "array",
           "items": {

--- a/lexicons/fyi/atstore/directory/searchListings.json
+++ b/lexicons/fyi/atstore/directory/searchListings.json
@@ -16,6 +16,13 @@
         "appTags",
         "categorySlugs"
       ],
+      "nullable": [
+        "iconUrl",
+        "heroImageUrl",
+        "categorySlug",
+        "rating",
+        "productAccountHandle"
+      ],
       "properties": {
         "uri": {
           "type": "string",
@@ -26,16 +33,14 @@
         "name": { "type": "string", "maxLength": 640 },
         "tagline": { "type": "string", "maxLength": 2000 },
         "description": { "type": "string", "maxLength": 20000 },
-        "iconUrl": { "type": "string", "maxLength": 8192, "nullable": true },
+        "iconUrl": { "type": "string", "maxLength": 8192 },
         "heroImageUrl": {
           "type": "string",
-          "maxLength": 8192,
-          "nullable": true
+          "maxLength": 8192
         },
         "categorySlug": {
           "type": "string",
-          "maxLength": 512,
-          "nullable": true
+          "maxLength": 512
         },
         "categorySlugs": {
           "type": "array",
@@ -49,15 +54,13 @@
         },
         "rating": {
           "type": "string",
-          "maxLength": 16,
-          "nullable": true
+          "maxLength": 16
         },
         "reviewCount": { "type": "integer" },
         "priceLabel": { "type": "string", "maxLength": 32 },
         "productAccountHandle": {
           "type": "string",
-          "maxLength": 512,
-          "nullable": true
+          "maxLength": 512
         },
         "appTags": {
           "type": "array",

--- a/lexicons/fyi/atstore/reviews/listForListing.json
+++ b/lexicons/fyi/atstore/reviews/listForListing.json
@@ -12,11 +12,17 @@
         "replyCount",
         "canReply"
       ],
+      "nullable": [
+        "text",
+        "authorDisplayName",
+        "authorHandle",
+        "authorAvatarUrl"
+      ],
       "properties": {
         "id": { "type": "string", "maxLength": 64 },
         "authorDid": { "type": "string", "format": "did", "maxLength": 2048 },
         "rating": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "text": { "type": "string", "maxLength": 8000, "nullable": true },
+        "text": { "type": "string", "maxLength": 8000 },
         "reviewCreatedAt": {
           "type": "string",
           "format": "datetime",
@@ -24,18 +30,15 @@
         },
         "authorDisplayName": {
           "type": "string",
-          "maxLength": 640,
-          "nullable": true
+          "maxLength": 640
         },
         "authorHandle": {
           "type": "string",
-          "maxLength": 512,
-          "nullable": true
+          "maxLength": 512
         },
         "authorAvatarUrl": {
           "type": "string",
-          "maxLength": 8192,
-          "nullable": true
+          "maxLength": 8192
         },
         "replyCount": { "type": "integer" },
         "canReply": { "type": "boolean" }


### PR DESCRIPTION
Hi! I was trying out the lexicons. And noticed that I got errors with `@atproto/lex` when using them. Saying that `null` was received instead of say `string` on for example `listing.rating`. Two examples are `atmo.rsvp` and `flashes`.
So I thought for a while that the bug was `@atproto/lex` not supporting the `nullable` fields.
But then I figured that `nullable` is an array like `required` next to `properties`, instead of on each field.
See <https://atproto.com/specs/lexicon#object>.

I am not the atproto expert here, so I may be missing something? But this seems to be the fix locally for me!

Thanks!