### PR TITLE
Fix nullable, required fields

### DIFF
--- a/lexicons/fyi/atstore/directory/getListing.json
+++ b/lexicons/fyi/atstore/directory/getListing.json
@@ -14,7 +14,12 @@
         "reviewCount",
         "priceLabel",
         "appTags",
-        "categorySlugs"
+        "categorySlugs",
+        "iconUrl",
+        "heroImageUrl",
+        "categorySlug",
+        "rating",
+        "productAccountHandle"
       ],
       "nullable": [
         "iconUrl",
@@ -78,7 +83,18 @@
     },
     "listingDetailResponse": {
       "type": "object",
-      "required": ["listing", "isStoreManaged"],
+      "required": [
+        "listing",
+        "isStoreManaged",
+        "repoDid",
+        "productAccountDid",
+        "sourceTagline",
+        "sourceFullDescription",
+        "externalUrl",
+        "sourceUrl",
+        "createdAt",
+        "updatedAt"
+      ],
       "nullable": [
         "repoDid",
         "productAccountDid",

--- a/lexicons/fyi/atstore/directory/searchListings.json
+++ b/lexicons/fyi/atstore/directory/searchListings.json
@@ -14,7 +14,12 @@
         "reviewCount",
         "priceLabel",
         "appTags",
-        "categorySlugs"
+        "categorySlugs",
+        "iconUrl",
+        "heroImageUrl",
+        "categorySlug",
+        "rating",
+        "productAccountHandle"
       ],
       "nullable": [
         "iconUrl",

--- a/lexicons/fyi/atstore/reviews/listForListing.json
+++ b/lexicons/fyi/atstore/reviews/listForListing.json
@@ -10,7 +10,11 @@
         "rating",
         "reviewCreatedAt",
         "replyCount",
-        "canReply"
+        "canReply",
+        "text",
+        "authorDisplayName",
+        "authorHandle",
+        "authorAvatarUrl"
       ],
       "nullable": [
         "text",

--- a/src/lexicons/generated/bundle.ts
+++ b/src/lexicons/generated/bundle.ts
@@ -37,7 +37,7 @@ export const lexicons = [
       "main": {
         "type": "permission-set",
         "title": "Submit AT Store reviews",
-        "detail": "Create fyi.atstore.profile/self when needed and fyi.atstore.listing.review records on the user's PDS via repository APIs; read public directory data via XRPC queries.",
+        "detail": "Create reviews on AT Store listings",
         "permissions": [
           {
             "type": "permission",
@@ -79,7 +79,12 @@ export const lexicons = [
           "reviewCount",
           "priceLabel",
           "appTags",
-          "categorySlugs"
+          "categorySlugs",
+          "iconUrl",
+          "heroImageUrl",
+          "categorySlug",
+          "rating",
+          "productAccountHandle"
         ],
         "nullable": [
           "iconUrl",
@@ -184,7 +189,15 @@ export const lexicons = [
         "type": "object",
         "required": [
           "listing",
-          "isStoreManaged"
+          "isStoreManaged",
+          "repoDid",
+          "productAccountDid",
+          "sourceTagline",
+          "sourceFullDescription",
+          "externalUrl",
+          "sourceUrl",
+          "createdAt",
+          "updatedAt"
         ],
         "nullable": [
           "repoDid",
@@ -308,7 +321,12 @@ export const lexicons = [
           "reviewCount",
           "priceLabel",
           "appTags",
-          "categorySlugs"
+          "categorySlugs",
+          "iconUrl",
+          "heroImageUrl",
+          "categorySlug",
+          "rating",
+          "productAccountHandle"
         ],
         "nullable": [
           "iconUrl",
@@ -782,7 +800,11 @@ export const lexicons = [
           "rating",
           "reviewCreatedAt",
           "replyCount",
-          "canReply"
+          "canReply",
+          "text",
+          "authorDisplayName",
+          "authorHandle",
+          "authorAvatarUrl"
         ],
         "nullable": [
           "text",


### PR DESCRIPTION
This is a follow up to GH-52, which caused `goat`
to emit warnings.
Goat does not want fields to be nullable *and* optional. But either nullable and required. Or non-nullable and optional.

See: <https://github.com/bluesky-social/indigo/blob/dfe5578f/lex/lexlint/lint.go#L330-L340>.

Related-to GH-52.

This also regenerates the `bundle.ts` which picks up a change that landed over the weekend without updating.